### PR TITLE
When next action is available, replaces status

### DIFF
--- a/.template.env
+++ b/.template.env
@@ -9,7 +9,7 @@ export ASSETS_URL="$WWW_URL/assets"
 export APP_LOGO="$WWW_URL/assets/liquid-us-logo.png"
 
 # Google Maps Address Autocompletion
-export GOOGLE_GEOCODER_KEY=""
+export GOOGLE_GEOCODER_KEY="AIzaSyCJYJN-fUm5FqN8-DvFYz-9GH8hokSCbdQ"
 
 # Affects Build Settings
 export NODE_ENV="development"

--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -219,12 +219,11 @@ const measureListRow = (s) => {
               ${s.summary ? [`
                 <p class="is-hidden-tablet"><strong class="has-text-grey">Has summary</strong></p>
               `] : []}
-              <p><strong class="has-text-grey">Status:</strong> ${s.status}</p>
+              <p><strong class="has-text-grey">Status:</strong>
               ${next_action_at ? [`
-                <strong class="has-text-grey">Next action:</strong>
                 Scheduled for House floor action ${!s.next_agenda_action_at ? 'during the week of' : 'on'} ${new Date(next_action_at).toLocaleDateString()}
                 <br />
-              `] : ''}
+              `] : `${s.status}</p>`}
               <strong class="has-text-grey">Last action:</strong> ${new Date(s.last_action_at).toLocaleDateString()}
             </div>
             `] : [`


### PR DESCRIPTION
On the Legislation List, the only next action that shows up is "Scheduled for House floor action during the week of 12/10/2018," which is essentially a more detailed version of "Awaiting floor or committee vote"

This makes it so that "Scheduled for..." becomes the status rather than an additional line of text