### PR TITLE
don't show addAddressNotification once user has address

### DIFF
--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -150,7 +150,7 @@ const filterForm = (geoip, legislatures, storage, location, user, dispatch) => {
         </div>
         <button type="submit" class="filter-submit is-hidden">Update</button>
       </div>
-      ${geoip ? [addAddressNotification(geoip, user)] : []}
+      ${(!user || !user.address) && geoip ? [addAddressNotification(geoip, user)] : []}
     </form>
   `
 }


### PR DESCRIPTION
found that there's a weird edge case where user has address and geoip is still set. The addAddressNotification was only checking if geoip was set, which was creating false positives. This PR limits addAddressNotification to not show once they have added an address