### PR TITLE
Comment social2

### DIFF
--- a/components/CommentPage.js
+++ b/components/CommentPage.js
@@ -50,7 +50,7 @@ module.exports = class CommentPage extends Component {
 
           const anonymousName = `${measure.legislature_name === 'U.S. Congress' ? 'American' : (stateNames[measure.legislature_name] || measure.legislature_name)} Resident`
 
-          const page_title = `${comment.fullname || anonymousName} voted ${comment.position} on ${measure.legislature_name}: ${measure.title}`
+          const page_title = `${comment.fullname || anonymousName} voted ${comment.position} on ${measure.title}`
           if (this.isBrowser) {
             const page_title_with_appname = `${page_title} | ${config.APP_NAME}`
             window.document.title = page_title_with_appname

--- a/components/CommentPage.js
+++ b/components/CommentPage.js
@@ -59,6 +59,7 @@ module.exports = class CommentPage extends Component {
 
           const measureImage = measure.legislature_name === 'WI' ? `${ASSETS_URL}/${measure.legislature_name}.png` : ''
           const authorImage = comment.username || comment.twitter_username ? this.avatarURL(comment) : null
+          const billImage = measure.title === 'Should the City of Madison develop a Bus Rapid Transit service?' ? `${ASSETS_URL}/madison-brt.png` : ''
           const ogImage = authorImage || measureImage
 
           this.setState({


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39286778/49821037-1280d480-fd3f-11e8-8a46-453286178e54.png)

Comments have the wrong image and it looks bad when the user is anonymous (repeats Madison, WI)

This adds a line to have comments for the BRT pull pull the brt.png image. It also removes the state legislature name from the page title for comments only