### PR TITLE
Endorsement sidebar

### DIFF
--- a/components/EndorsementPageSidebar.js
+++ b/components/EndorsementPageSidebar.js
@@ -14,7 +14,7 @@ module.exports = class EndorsementPageSidebar extends Component {
 
     return this.html`
 
-      ${measure.user && measure.vote_position && !measure.comment.endorsed && measure.author_username !== user.username
+      ${measure.user && measure.vote_position && !measure.comment.endorsed && measure.comment.username !== user.username
         // logged in, voted differently
         ? VotedDifferentlyMessage.for(this, { measure }) : ''
       }
@@ -25,7 +25,7 @@ module.exports = class EndorsementPageSidebar extends Component {
         ${!measure.user // logged out
           ? NewSignupEndorseForm.for(this, { measure })
 
-          : measure.comment.endorsed || measure.author_username === user.username // logged in, already endorsed
+          : measure.comment.endorsed || measure.comment.username === user.username // logged in, already endorsed
             ? module.exports.AfterEndorseSocialShare.for(this, { measure })
 
 

--- a/components/EndorsementPageSidebar.js
+++ b/components/EndorsementPageSidebar.js
@@ -15,7 +15,7 @@ module.exports = class EndorsementPageSidebar extends Component {
 
     return this.html`
 
-      ${measure.user && measure.vote_position && !measure.comment.endorsed
+      ${measure.user && measure.vote_position && !measure.comment.endorsed && measure.author_username !== user.username
         // logged in, voted differently
         ? VotedDifferentlyMessage.for(this, { measure }) : ''
       }
@@ -26,7 +26,7 @@ module.exports = class EndorsementPageSidebar extends Component {
         ${!measure.user // logged out
           ? NewSignupEndorseForm.for(this, { measure })
 
-          : measure.comment.endorsed // logged in, already endorsed
+          : measure.comment.endorsed || measure.author_username === user.username // logged in, already endorsed
             ? module.exports.AfterEndorseSocialShare.for(this, { measure })
             : notMyLegislature === 'invalid' // Logged in, wrong juridstiction
             ? module.exports.WrongJuridstictionSocialShare.for(this, { measure })
@@ -345,7 +345,7 @@ module.exports.AfterEndorseSocialShare = class AfterEndorseSocialShare extends C
 
     let actionIng = 'endorsing'; let actionTo = 'endorse'
     if (comment.position === 'nay') { actionIng = 'opposing'; actionTo = 'oppose' }
-    if (comment.position === 'abstain') { actionIng = 'voting on'; actionTo = 'vote now' }
+    if (comment.position === 'abstain') { actionIng = 'abstaining'; actionTo = 'abstain' }
     const share_text = `Join me in ${actionIng} ${title}: ${share_url}`
 
     return this.html`

--- a/components/EndorsementPageSidebar.js
+++ b/components/EndorsementPageSidebar.js
@@ -11,7 +11,6 @@ module.exports = class EndorsementPageSidebar extends Component {
   render() {
     const measure = this.props
     const user = measure.user
-    const notMyLegislature = measure.legislature_name === 'U.S. Congress' ? 'valid' : ~measure.legislature_name.indexOf(',') && user && measure.legislature_name === user.address.city ? 'valid' : ~measure.legislature_name.indexOf(',') ? 'invalid' : measure.legislature_name !== user.address.state ? 'invalid' : 'valid'
 
     return this.html`
 
@@ -28,8 +27,6 @@ module.exports = class EndorsementPageSidebar extends Component {
 
           : measure.comment.endorsed || measure.author_username === user.username // logged in, already endorsed
             ? module.exports.AfterEndorseSocialShare.for(this, { measure })
-            : notMyLegislature === 'invalid' // Logged in, wrong juridstiction
-            ? module.exports.WrongJuridstictionSocialShare.for(this, { measure })
 
 
             : // logged in, voted differently or haven't voted
@@ -351,39 +348,6 @@ module.exports.AfterEndorseSocialShare = class AfterEndorseSocialShare extends C
     return this.html`
       <div class="content">
         <p class="has-text-weight-semibold">Increase your impact by asking your friends and family to ${actionTo}.</p>
-        <div class="buttons is-centered">
-          <a class="button is-link has-text-weight-bold" title="Share on Facebook" target="_blank" href="${`https://www.facebook.com/sharer/sharer.php?u=${share_url}`}">
-            <span class="icon"><i class="fab fa-facebook"></i></span>
-            <span>Post on Facebook</span>
-          </a>
-          <a class="button is-link has-text-weight-bold" title="Share on Twitter" target="_blank" href="${`https://twitter.com/intent/tweet?text=${share_text}`}">
-            <span class="icon"><i class="fab fa-twitter"></i></span>
-            <span>Tweet your people</span>
-          </a>
-          <a class="button is-link has-text-weight-bold" title="Share with Email" target="_blank" href="${`mailto:?subject=${title}&body=${share_text}`}">
-            <span class="icon"><i class="fa fa-envelope"></i></span>
-            <span>Email</span>
-          </a>
-        </div>
-      </div>
-    `
-  }
-}
-module.exports.WrongJuridstictionSocialShare = class WrongJuridstictionSocialShare extends Component {
-  render() {
-    const { author_username, comment, id, short_id, title, type } = this.props.measure
-    const measure_url = `${author_username ? `/${author_username}/` : '/'}${type === 'nomination' ? 'nominations' : 'legislation'}/${short_id}`
-    const comment_url = `${measure_url}/votes/${id}`
-    const share_url = `${WWW_URL}${comment_url}`
-
-    let actionShare = 'support'; let actionTo = 'endorse'
-    if (comment.position === 'nay') { actionShare = 'stop'; actionTo = 'oppose' }
-    if (comment.position === 'abstain') { actionShare = 'gather feedback on'; actionTo = 'vote now' }
-    const share_text = `Help ${actionShare} ${title}: ${share_url}`
-
-    return this.html`
-      <div class="content">
-        <p class="has-text-weight-semibold">Ask your friends and family to ${actionTo}.</p>
         <div class="buttons is-centered">
           <a class="button is-link has-text-weight-bold" title="Share on Facebook" target="_blank" href="${`https://www.facebook.com/sharer/sharer.php?u=${share_url}`}">
             <span class="icon"><i class="fab fa-facebook"></i></span>

--- a/components/EndorsementPageSidebar.js
+++ b/components/EndorsementPageSidebar.js
@@ -345,7 +345,7 @@ module.exports.AfterEndorseSocialShare = class AfterEndorseSocialShare extends C
 
     let actionIng = 'endorsing'; let actionTo = 'endorse'
     if (comment.position === 'nay') { actionIng = 'opposing'; actionTo = 'oppose' }
-    if (comment.position === 'abstain') { actionIng = 'abstaining on'; actionTo = 'abstain' }
+    if (comment.position === 'abstain') { actionIng = 'voting on'; actionTo = 'vote now' }
     const share_text = `Join me in ${actionIng} ${title}: ${share_url}`
 
     return this.html`


### PR DESCRIPTION
I did the work for the first commit before I saw the discussion about allowing outside votes, so the last commit reverts that.

Second commit: current language "Tell your friends and family to vote abstain" seems weird, and there'd be a pretty small use case. I think more people are likely to share a comment like that that's asking for feedback or encouraging people to vote on the bill. Vote/vote now seems safer/more generic

Third commit: On my own comment page, the sidebar was treating me as if I needed to endorse a different position. This commit expands the AfterEndorseSocialShare so that it appears when it's the user's own comment. Also removes the votedDifferentlyMessage from the top of the sidebar