### PR TITLE
removes You are representing X proxies language if signed out

### DIFF
--- a/components/MeasureVoteForm.js
+++ b/components/MeasureVoteForm.js
@@ -204,7 +204,7 @@ class MeasureVoteForm extends Component {
         <div class="field">
           <h4 class="title is-size-6">${!v.comment ? 'Add your argument' : 'Edit your argument'}:</h4>
         </div>
-        ${v.id && !v.comment && public_checked ? [`
+        ${v.id && !v.comment && l.vote_power !== undefined && public_checked ? [`
           <p class="notification">
             <span class="icon"><i class="fa fa-users"></i></span>
             ${v.id ? 'You cast' : 'You are casting'}
@@ -233,13 +233,13 @@ class MeasureVoteForm extends Component {
             </div>
             <div class="column">
               <div class="control has-text-right has-text-left-mobile has-text-grey is-size-7">
-                ${[public_checked ? `
+                ${[public_checked && l.vote_power !== undefined ? `
                     <span class="icon"><i class="fas fa-users"></i></span>You are casting
                     a vote for <span class="has-text-weight-semibold">${l.vote_power}</span> people as their proxy.
-                ` : `
+                ` : l.vote_power !== undefined ? `
                     <span class="icon"><i class="fas fa-address-book"></i></span>You are casting
                     a private vote for yourself only. Only you can see it.
-                `]}
+                ` : '']}
               </div>
             </div>
           </div>


### PR DESCRIPTION
If you're signed out and press Add an argument, this message shows up:

You are casting a vote for undefined people as their proxy.

This code removes that message and accompanying icon when logged out

Tested on local server