### PR TITLE
Adds all legislators to bill page [for review]

### DIFF
--- a/components/MeasureDetailsSidebar.js
+++ b/components/MeasureDetailsSidebar.js
@@ -249,19 +249,32 @@ class MeasureVoteCounts extends Component {
     `
   }
 }
+const repCheck = ([measure], [reps]) => {
+  console.log(measure.legislature_name === reps[4].legislature.name ? reps[0].legislature.name : '')
+  const relevantReps = []
+  for (let i = 0; i < reps.length; i++) {
+  if (measure.legislature_name === reps[i].legislature.name) {
+    relevantReps.push(reps[i])
+    }
+  }
+  return relevantReps
+}
 
 class MeasureRepsPanel extends Component {
   render() {
-    const { measure, reps = [] } = this.props
+    const { measure } = this.props
+    const { reps = [] } = this.state
+    const relevantReps = repCheck([measure], [reps])
+    console.log(relevantReps)
     return this.html`
       <div class="panel-block">
         <div>
           <h4 class="has-text-centered has-text-weight-semibold" style="margin: 0 0 .5rem;">
             ${measure.vote_position
-            ? `We told your rep${reps.length > 1 ? 's' : ''} to vote ${measure.vote_position}`
-            : `Vote to tell your rep${reps.length > 1 ? 's' : ''}`}
+            ? `We told your rep${relevantReps.length > 1 ? 's' : ''} to vote ${measure.vote_position}`
+            : `Vote to tell your rep${relevantReps.length > 1 ? 's' : ''}`}
           </h4>
-          ${reps.map((rep) => RepSnippet.for(this, { rep: rep.office_holder, office: rep }, `sidebar-rep-${rep.office_holder.user_id}`))}
+          ${relevantReps.map((rep) => RepSnippet.for(this, { rep: rep.office_holder, office: rep }, `sidebar-rep-${rep.office_holder.user_id}`))}
         </div>
       </div>
     `

--- a/components/MeasureDetailsSidebar.js
+++ b/components/MeasureDetailsSidebar.js
@@ -249,8 +249,7 @@ class MeasureVoteCounts extends Component {
     `
   }
 }
-const repCheck = ([measure], [reps]) => {
-  console.log(measure.legislature_name === reps[4].legislature.name ? reps[0].legislature.name : '')
+const repCheck = (measure, reps) => {
   const relevantReps = []
   for (let i = 0; i < reps.length; i++) {
   if (measure.legislature_name === reps[i].legislature.name) {
@@ -264,8 +263,7 @@ class MeasureRepsPanel extends Component {
   render() {
     const { measure } = this.props
     const { reps = [] } = this.state
-    const relevantReps = repCheck([measure], [reps])
-    console.log(relevantReps)
+    const relevantReps = repCheck(measure, reps)
     return this.html`
       <div class="panel-block">
         <div>


### PR DESCRIPTION
Currently we show only the legislators for the relevant chamber. This changes it so we show both chambers by matching legislator.legislature.name to measure.legislature_name.

The new comment page now shows all legislators for the state and I feel like we should do the same on the bill page.