### PR TITLE
sets the paragraph showing status to hidden for s.leg_name===WI

### DIFF
--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -230,11 +230,11 @@ const measureListRow = (s) => {
               ${s.summary ? [`
                 <p class="is-hidden-tablet"><strong class="has-text-grey">Has summary</strong></p>
               `] : []}
-              <p><strong class="has-text-grey">Status:</strong>
+              <p><strong class="has-text-grey${s.legislature_name === 'WI' ? ' is-hidden' : ''}">Status:</strong>
               ${next_action_at ? [`
                 Scheduled for House floor action ${!s.next_agenda_action_at ? 'during the week of' : 'on'} ${new Date(next_action_at).toLocaleDateString()}
                 <br />
-              `] : `${s.status}</p>`}
+              `] : s.legislature_name === 'WI' ? '' : `${s.status}</p>`}
               <strong class="has-text-grey">Last action:</strong> ${new Date(s.last_action_at).toLocaleDateString()}
             </div>
             `] : [`


### PR DESCRIPTION
openstates is missing data we use to pull status for WI. I've set up a different PR to change how we incorporate status in the backend, but until that's in place I'd like to hide status for WI bills.

I've tested this successfully on my local server