### PR TITLE
sets the paragraph showing status to hidden for s.leg_name===WI

### DIFF
--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -230,12 +230,12 @@ const measureListRow = (s) => {
               ${s.summary ? [`
                 <p class="is-hidden-tablet"><strong class="has-text-grey">Has summary</strong></p>
               `] : []}
-              <p><strong class="has-text-grey">Status:</strong>
+              <p${s.legislature_name === 'WI' ? ' class="is-hidden"' : ''}><strong class="has-text-grey">Status:</strong>
               ${next_action_at ? [`
                 Scheduled for House floor action ${!s.next_agenda_action_at ? 'during the week of' : 'on'} ${new Date(next_action_at).toLocaleDateString()}
                 <br />
               `] : `${s.status}</p>`}
-              <strong class="has-text-grey">Last action:</strong> ${new Date(s.last_action_at).toLocaleDateString()}
+              <p><strong class="has-text-grey">Last action:</strong> ${new Date(s.last_action_at).toLocaleDateString()}</p>
             </div>
             `] : [`
               <div class="is-size-7 has-text-grey">

--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -233,8 +233,7 @@ const measureListRow = (s) => {
               <p${s.legislature_name === 'WI' ? ' class="is-hidden"' : ''}><strong class="has-text-grey">Status:</strong>
               ${next_action_at ? [`
                 Scheduled for House floor action ${!s.next_agenda_action_at ? 'during the week of' : 'on'} ${new Date(next_action_at).toLocaleDateString()}
-                <br />
-              `] : `${s.status}</p>`}
+              `] : `${s.status}`}</p>
               <p><strong class="has-text-grey">Last action:</strong> ${new Date(s.last_action_at).toLocaleDateString()}</p>
             </div>
             `] : [`


### PR DESCRIPTION
openstates is missing data we use to pull status for WI. I've set up a different PR to change how we incorporate status in the backend, but until that's in place I'd like to hide status for WI bills.

makes Latest action into a paragraph to put on its own line and fixed paragraph for status that is currently broken by the if-then statement