### PR TITLE
Share data checkboxes

### DIFF
--- a/components/Comment.js
+++ b/components/Comment.js
@@ -53,14 +53,14 @@ module.exports = class Comment extends Component {
   endorse() {
     const { measures = {}, offices = [], user } = this.state
     const endorsed_vote = !(this.state.user && this.state.user.id === this.props.user_id && this.props.comment) && this.props.endorsed_vote
-    const { fullname, measure_id, short_id, id: vote_id, public: is_public } = endorsed_vote || this.props
+    const { author_username, fullname, measure_id, short_id, type, id: vote_id, public: is_public } = endorsed_vote || this.props
     const measure = measures[short_id]
     const position = measure && measure.vote_position
     if (!user) {
       this.storage.set('endorsed_vote_id', vote_id)
       this.storage.set('endorsed_measure_id', measure_id)
       this.storage.set('endorsed_url', `/legislation/${short_id}/votes/${vote_id}`)
-      return this.location.redirect('/join')
+      return this.location.redirect(`${author_username ? `/${author_username}/` : '/'}${type === 'nomination' ? 'nominations' : 'legislation'}/${short_id}/votes/${vote_id}`)
     }
     if (position) {
       let confirmation_text = 'You\'ve already '

--- a/components/EndorsementPageMobileForm.js
+++ b/components/EndorsementPageMobileForm.js
@@ -36,6 +36,33 @@ module.exports = class EndorsementPageMobileForm extends Component {
         .modal-content, .modal-card {
           max-height: calc(100vh - 100px) !important;
         }
+        .share-tooltip {
+          position: relative;
+        }
+        .share-tooltip .share-tooltip-content {
+          display: none;
+          position: absolute;
+          max-height: 222px;
+        }
+        .share-tooltip:hover .share-tooltip-content {
+          display: block;
+          background: hsl(0, 0%, 100%) !important;
+          box-shadow: 0px 4px 15px hsla(0, 0%, 0%, 0.15);
+          border: 1px solid hsl(0, 0%, 87%);
+          color: #333;
+          font-size: 14px;
+          overflow: hidden;
+          padding: .4rem;
+          margin-left: 3rem;
+          text-align: center;
+          white-space: normal;
+          z-index: 99999;
+          top: auto;
+          bottom: 0%;
+          left: 0%;
+          right: 0%;
+          transform: translate(-0.5rem, 50%);
+        }
 
         @media (min-width: 1050px) {
           .mobile-only {
@@ -106,6 +133,33 @@ class NewSignupEndorseMobileForm extends NewSignupEndorseForm {
               Share my name publicly
             </label>
           </div>
+        </div>
+        <div class="${`field ${measure.author_username === measure.comment.username || measure.comment.public === false ? '' : 'is-hidden'}`}">
+          <div class="control share-tooltip">
+            <label class="checkbox">
+              <input name="share_bill_author" type="checkbox" checked />
+              Share my contact information with ${measure.author_first_name} ${measure.author_last_name}
+            </label>
+            &nbsp<div class="share-tooltip-content">Receive updates about this proposal and related bills.</div>
+          </div>
+        </div>
+        <div class="${`field share-tooltip ${measure.author_username === measure.comment.username || measure.comment.public === false ? 'is-hidden' : ''}`}">
+          <div class="is-size-6">Share my contact information with:</div>
+          <div class="field">
+            <div class="control">
+              <label class="checkbox">
+                &nbsp&nbsp<input name="share_comment_author" type="checkbox" checked />
+                ${measure.comment.fullname}
+              </label>
+            </div>
+            <div class="control">
+              <label class="checkbox">
+                &nbsp&nbsp<input name="share_bill_author" type="checkbox" checked />
+                ${measure.author_first_name} ${measure.author_last_name}
+              </label>
+            </div>
+          </div>
+          &nbsp<div class="share-tooltip-content">Receive updates about this proposal and related bills.</div>
         </div>
         <div class="field">
           <div class="control">
@@ -185,6 +239,33 @@ class LoggedInMobileForm extends LoggedInForm {
               Share my name publicly
             </label>
           </div>
+        </div>
+        <div class="${`field ${measure.author_username === measure.comment.username || measure.comment.public === false ? '' : 'is-hidden'}`}">
+          <div class="control share-tooltip">
+            <label class="checkbox">
+              <input name="share_bill_author" type="checkbox" checked />
+              Share my contact information with ${measure.author_first_name} ${measure.author_last_name}
+            </label>
+            &nbsp<div class="share-tooltip-content">Receive updates about this proposal and related bills.</div>
+          </div>
+        </div>
+        <div class="${`field share-tooltip ${measure.author_username === measure.comment.username || measure.comment.public === false ? 'is-hidden' : ''}`}">
+          <div class="is-size-6">Share my contact information with:</div>
+          <div class="field">
+            <div class="control">
+              <label class="checkbox">
+                &nbsp&nbsp<input name="share_comment_author" type="checkbox" checked />
+                ${measure.comment.fullname}
+              </label>
+            </div>
+            <div class="control">
+              <label class="checkbox">
+                &nbsp&nbsp<input name="share_bill_author" type="checkbox" checked />
+                ${measure.author_first_name} ${measure.author_last_name}
+              </label>
+            </div>
+          </div>
+          &nbsp<div class="share-tooltip-content">Receive updates about this proposal and related bills.</div>
         </div>
         <div class="field">
           <div class="control">

--- a/components/EndorsementPageSidebar.js
+++ b/components/EndorsementPageSidebar.js
@@ -105,7 +105,7 @@ module.exports.NewSignupEndorseForm = class NewSignupEndorseForm extends Compone
         // Store endorsement
         .then(() => this.api('/rpc/endorse', {
           method: 'POST',
-          body: JSON.stringify({ user_id: user.id, vote_id, measure_id: measure.id, public: formData.is_public === 'on' }),
+          body: JSON.stringify({ user_id: user.id, vote_id, measure_id: measure.id, public: formData.is_public === 'on', data: formData.share_data === 'on' }),
         }))
         // Get new endorsement count
         .then(() => this.api(`/votes_detailed?id=eq.${vote_id}`))
@@ -180,11 +180,68 @@ module.exports.NewSignupEndorseForm = class NewSignupEndorseForm extends Compone
             </label>
           </div>
         </div>
+        <div class="${`field ${measure.author_username === measure.comment.username || measure.comment.public === false ? '' : 'is-hidden'}`}">
+          <div class="control share-tooltip">
+            <label class="checkbox">
+              <input name="share_bill_author" type="checkbox" checked />
+              Share my contact information with ${measure.author_first_name} ${measure.author_last_name}
+            </label>
+            &nbsp<div class="share-tooltip-content">Receive updates about this proposal and related bills.</div>
+          </div>
+        </div>
+        <div class="${`field share-tooltip ${measure.author_username === measure.comment.username || measure.comment.public === false ? 'is-hidden' : ''}`}">
+          <div class="is-size-6">Share my contact information with:</div>
+          <div class="field">
+            <div class="control">
+              <label class="checkbox">
+                &nbsp&nbsp<input name="share_comment_author" type="checkbox" checked />
+                ${measure.comment.fullname}
+              </label>
+            </div>
+            <div class="control">
+              <label class="checkbox">
+                &nbsp&nbsp<input name="share_bill_author" type="checkbox" checked />
+                ${measure.author_first_name} ${measure.author_last_name}
+              </label>
+            </div>
+          </div>
+          &nbsp<div class="share-tooltip-content">Receive updates about this proposal and related bills.</div>
+        </div>
         <div class="field">
           <div class="control">
             <button class=${`button ${color} is-fullwidth has-text-weight-bold is-size-5`} type="submit">${action}</button>
           </div>
-        </div>
+          <style>
+          .share-tooltip {
+            position: relative;
+          }
+          .share-tooltip .share-tooltip-content {
+            display: none;
+            position: absolute;
+            max-height: 222px;
+          }
+          .share-tooltip:hover .share-tooltip-content {
+            display: block;
+            background: hsl(0, 0%, 100%) !important;
+            box-shadow: 0px 4px 15px hsla(0, 0%, 0%, 0.15);
+            border: 1px solid hsl(0, 0%, 87%);
+            color: #333;
+            font-size: 14px;
+            overflow: hidden;
+            padding: .4rem;
+            text-align: center;
+            white-space: normal;
+            width: 200px;
+            z-index: 99999;
+            top: auto;
+            bottom: 0%;
+            left: 0%;
+            right: 0%;
+            transform: translate(-0.5rem, 50%);
+          }
+        </style>
+      </div>
+
       </form>
     `
   }
@@ -241,7 +298,7 @@ module.exports.LoggedInForm = class LoggedInForm extends Component {
     const { measure } = this.props
     const { comment } = measure
     const vote_id = comment.id
-    const endorsement = { user_id: user.id, vote_id, measure_id: measure.id, public: formData.is_public === 'on' }
+    const endorsement = { user_id: user.id, vote_id, measure_id: measure.id, public: formData.is_public === 'on', data: formData.share_data === 'on' }
 
     if (user.first_name) {
       return this.endorse(endorsement).catch((error) => console.log(error))
@@ -299,12 +356,39 @@ module.exports.LoggedInForm = class LoggedInForm extends Component {
           <p class="is-size-7" style="margin-top: .3rem;">So your reps know you're their constituent.</p>
         </div>
         <div class="field">
-          <div class="control">
+          <div class="control" style="max-width: 1rem">
             <label class="checkbox">
               <input name="is_public" type="checkbox" checked=${last_vote_public} />
               Share my name publicly
             </label>
           </div>
+        </div>
+        <div class="${`field ${measure.author_username === measure.comment.username || measure.comment.public === false ? '' : 'is-hidden'}`}">
+          <div class="control share-tooltip">
+            <label class="checkbox">
+              <input name="share_bill_author" type="checkbox" checked />
+              Share my contact information with ${measure.author_first_name} ${measure.author_last_name}
+            </label>
+            &nbsp<div class="share-tooltip-content">Receive updates about this proposal and related bills.</div>
+          </div>
+        </div>
+        <div class="${`field share-tooltip ${measure.author_username === measure.comment.username || measure.comment.public === false ? 'is-hidden' : ''}`}">
+          <div class="is-size-6">Share my contact information with:</div>
+          <div class="field">
+            <div class="control">
+              <label class="checkbox">
+                &nbsp&nbsp<input name="share_comment_author" type="checkbox" checked />
+                ${measure.comment.fullname}
+              </label>
+            </div>
+            <div class="control">
+              <label class="checkbox">
+                &nbsp&nbsp<input name="share_bill_author" type="checkbox" checked />
+                ${measure.author_first_name} ${measure.author_last_name}
+              </label>
+            </div>
+          </div>
+          &nbsp<div class="share-tooltip-content">Receive updates about this proposal and related bills.</div>
         </div>
         <div class="field">
           <div class="control">

--- a/components/MeasureVoteForm.js
+++ b/components/MeasureVoteForm.js
@@ -249,6 +249,14 @@ class MeasureVoteForm extends Component {
             <textarea name="comment" autocomplete="off" class="textarea" placeholder="Add an argument. Why are you voting this way?" value=${v.comment || ''}></textarea>
           </div>
         </div>
+        <div class="${`field ${l.sponsor_username !== null ? 'is-hidden' : ''}`}">
+          <div class="control share-tooltip">
+              <input name="share_data" type="checkbox" checked />
+              Share my contact information with ${l.author_first_name} ${l.author_last_name}
+            </label>
+          </div>
+          <div>Receive updates on related proposals</div>
+        </div>
         <div class="field is-horizontal">
           <div class="field is-grouped">
             <div class="control">
@@ -266,6 +274,35 @@ class MeasureVoteForm extends Component {
               </div>
             </div>
           </div>
+          <style>
+          .share-tooltip {
+            position: relative;
+          }
+          .share-tooltip .share-tooltip-content {
+            display: none;
+            position: absolute;
+            max-height: 222px;
+          }
+          .share-tooltip:hover .share-tooltip-content {
+            display: block;
+            background: hsl(0, 0%, 100%) !important;
+            box-shadow: 0px 4px 15px hsla(0, 0%, 0%, 0.15);
+            border: 1px solid hsl(0, 0%, 87%);
+            color: #333;
+            font-size: 14px;
+            overflow: hidden;
+            padding: .4rem;
+            text-align: center;
+            white-space: normal;
+            width: 200px;
+            z-index: 99999;
+            top: auto;
+            bottom: 0%;
+            left: 0%;
+            right: 0%;
+            transform: translate(-0.5rem, 50%);
+          }
+        </style>
         </div>
         <hr />
       </form>


### PR DESCRIPTION
This change adds checkboxes when people sign up or vote asking if they want to share data with the bill author and/or the comment author.

This has been added to the endorsement page sidebar, desktop and mobile, and the bill page.
![image](https://user-images.githubusercontent.com/39286778/56065572-d71d0380-5d3a-11e9-8772-5c5441080c7a.png)

![image](https://user-images.githubusercontent.com/39286778/56066169-97efb200-5d3c-11e9-9f43-93d8383c6b0e.png)

![image](https://user-images.githubusercontent.com/39286778/56065606-f0be4b00-5d3a-11e9-852c-90596b167ca1.png)

![image](https://user-images.githubusercontent.com/39286778/56065639-0a5f9280-5d3b-11e9-94eb-dc71884a2340.png)

![image](https://user-images.githubusercontent.com/39286778/56065667-26fbca80-5d3b-11e9-95e4-36f419917c55.png)

I also changed the link new users click endorse so that they're taken to that comment's petition page. 

[ ] connect to backend so the data is recorded
[ ] on mobile, have endorse sign up box pop up by default when the user clicks the Endorse button
[ ] add pop-up when user is signed in and endorses bill. Pop up is a checkbox that asks if they want to share data 
---not sure if this is necessary for this push as most people will be signing up for the first time, but we shouldn't leave it unfinished for too long