### PR TITLE
Display state district names in friendlier manner (updated to new code)

### DIFF
--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -6,7 +6,7 @@ const editButtons = require('./measure-edit-buttons')
 const shareButtons = require('./measure-share-buttons')
 
 module.exports = (state, dispatch) => {
-  const { measure, offices, user } = state
+  const { measure, offices } = state
   const l = measure
   const reps = state.reps.filter(({ chamber, legislature }) => {
     return chamber === l.chamber && (stateAbbr[legislature.name] || legislature.name) === l.legislature_name
@@ -30,7 +30,7 @@ module.exports = (state, dispatch) => {
       </div>
       ${reps && reps.length ? measureRepsPanel({ measure, reps }) : ''}
       ${panelTitleBlock('Votes')}
-      ${measureVoteCounts({ measure, offices, user })}
+      ${measureVoteCounts({ measure, offices })}
       ${panelTitleBlock('Info')}
       ${measureInfoPanel({ measure, showStatusTracker })}
       ${measureActionsPanel(state, dispatch)}
@@ -153,6 +153,7 @@ const measureVoteCounts = ({ measure, offices }) => {
     'U.S. Congress': { Upper: 'Senate', Lower: 'House' },
     'CA': { Upper: 'Senate', Lower: 'Assembly' },
   }
+
   return html`
     <div class="panel-block">
       <div style="width: 100%;">
@@ -249,21 +250,33 @@ const measureRepsPanel = ({ measure, reps }) => {
     </div>
   `
 }
-const districtName = (measure, offices, localLegislatureName) => {
-  const cityDistrict = measure.legislature_name.includes(',') ? localLegislatureName.split('-') : ''
-    if (measure.legislature_name.includes('Congress')) {
-    return localLegislatureName
-  } else if (measure.legislature_name.includes(',')) {
-    return `District ${cityDistrict[2]}`
-  } else if (measure.chamber === 'Upper') {
-    return localLegislatureName.replace('U', ' S.D. ')
-  } else if (offices[3].name.includes('Assembly') || offices[4].name.includes('Assembly')) {
-    return localLegislatureName.replace('L', ' A.D. ')
-  } else if (offices[3].name.includes('House') || offices[3].name.includes('Representative') || offices[4].name.includes('House') || offices[4].name.includes('Representative')) {
-    return localLegislatureName.replace('L', ' H.D. ')
-  } else if (offices[3].name.includes('Legislature') || offices[4].name.includes('Legislature')) {
-    return localLegislatureName.replace('L', ' L.D. ')
+const districtName = (measure, offices, apiDistrictName) => {
+  // National bills are already labelled well
+  if (measure.legislature_name.includes('Congress')) {
+    return apiDistrictName
   }
+
+  // City bills: just show final district number
+  if (measure.legislature_name.includes(',')) {
+    return `District ${apiDistrictName.match(/[0-9]+$/)[0]}`
+  }
+
+  // All states call their upper chamber 'Senate'
+  if (measure.chamber === 'Upper') {
+    return apiDistrictName.replace('U', ' S.D. ')
+  }
+
+  // Nebraska has a unicameral state legislture
+  if (measure.legislature_name === 'NE') {
+    return apiDistrictName.replace('L', ' L.D. ')
+  }
+
+  // background: https://en.wikipedia.org/wiki/List_of_United_States_state_legislatures
+  if (offices.some(o => o.name && o.name.includes('Assembly'))) {
+    return apiDistrictName.replace('L', ' A.D. ')
+  }
+
+  return apiDistrictName.replace('L', ' H.D. ')
 }
 const repSnippet = ({ rep, office }) => html`
   <div>

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -148,22 +148,6 @@ const measureVoteCounts = ({ measure, offices }) => {
   const localLegislatureName = offices
     .filter((office) => office.id && office.legislature.name === measure.legislature_name && (!office.chamber || office.chamber === measure.chamber))
     .map((office) => office.short_name).pop()
-  const cityDistrict = legislature_name.includes(',') ? localLegislatureName.split('-') : ''
-
-
-  const districtName = legislature_name.includes('Congress')
-  ? localLegislatureName
-  : measure.legislature_name.includes(',')
-  ? `District ${cityDistrict[2]}`
-  : localLegislatureName && chamber === 'Upper'
-  ? localLegislatureName.replace('U', ' S.D. ')
-  : localLegislatureName && (offices[3].name.includes('Assembly') || offices[4].name.includes('Assembly'))
-  ? localLegislatureName.replace('L', ' A.D. ')
-  : localLegislatureName && (offices[3].name.includes('House') || offices[3].name.includes('Representative') || offices[4].name.includes('House') || offices[4].name.includes('Representative'))
-  ? localLegislatureName.replace('L', ' H.D. ')
-  : localLegislatureName && (offices[3].name.includes('Legislature') || offices[4].name.includes('Legislature'))
-  ? localLegislatureName.replace('L', ' L.D. ')
-  : ''
 
   const chamberNames = {
     'U.S. Congress': { Upper: 'Senate', Lower: 'House' },
@@ -205,7 +189,7 @@ const measureVoteCounts = ({ measure, offices }) => {
             </tr>
             ${offices.length && localLegislatureName ? html`
             <tr>
-              <td class="has-text-left has-text-grey">${districtName}</td>
+              <td class="has-text-left has-text-grey">${districtName(measure, offices, localLegislatureName)}</td>
               <td class="has-text-right">${constituent_yeas || 0}</td>
               <td class="has-text-right">${constituent_nays || 0}</td>
             </tr>
@@ -265,7 +249,22 @@ const measureRepsPanel = ({ measure, reps }) => {
     </div>
   `
 }
-
+const districtName = (measure, offices, localLegislatureName) => {
+  const cityDistrict = measure.legislature_name.includes(',') ? localLegislatureName.split('-') : ''
+    if (measure.legislature_name.includes('Congress')) {
+    return localLegislatureName
+  } else if (measure.legislature_name.includes(',')) {
+    return `District ${cityDistrict[2]}`
+  } else if (measure.chamber === 'Upper') {
+    return localLegislatureName.replace('U', ' S.D. ')
+  } else if (offices[3].name.includes('Assembly') || offices[4].name.includes('Assembly')) {
+    return localLegislatureName.replace('L', ' A.D. ')
+  } else if (offices[3].name.includes('House') || offices[3].name.includes('Representative') || offices[4].name.includes('House') || offices[4].name.includes('Representative')) {
+    return localLegislatureName.replace('L', ' H.D. ')
+  } else if (offices[3].name.includes('Legislature') || offices[4].name.includes('Legislature')) {
+    return localLegislatureName.replace('L', ' L.D. ')
+  }
+}
 const repSnippet = ({ rep, office }) => html`
   <div>
     <div class="media" style="margin-bottom: .5rem;">

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -145,14 +145,22 @@ const measureVoteCounts = ({ measure, offices }) => {
     legislature_name, chamber, delegate_name, vote_position, short_id
   } = measure
 
-  const localLegislatureName = offices
+  const firstChamber = offices
     .filter((office) => office.id && office.legislature.name === measure.legislature_name && (!office.chamber || office.chamber === measure.chamber))
     .map((office) => office.short_name).pop()
+
+  const stateDistrict = chamber === 'Upper'
+  ? firstChamber.replace(firstChamber[2], ' S.D. ')
+  : offices[4].name.includes('Assembly')
+  ? firstChamber.replace('L', ' A.D. ')
+  : offices[4].name.includes('House') || offices[4].name.includes('Representative')
+  ? firstChamber.replace('L', ' H.D. ')
+  : firstChamber.replace('L', ' L.D. ')
+    console.log(offices)
   const chamberNames = {
     'U.S. Congress': { Upper: 'Senate', Lower: 'House' },
     'CA': { Upper: 'Senate', Lower: 'Assembly' },
   }
-
   return html`
     <div class="panel-block">
       <div style="width: 100%;">
@@ -187,9 +195,9 @@ const measureVoteCounts = ({ measure, offices }) => {
               <td class="has-text-right">${yeas || 0}</td>
               <td class="has-text-right">${nays || 0}</td>
             </tr>
-            ${offices.length && localLegislatureName ? html`
+            ${offices.length && firstChamber ? html`
             <tr>
-              <td class="has-text-left has-text-grey">${localLegislatureName}</td>
+              <td class="has-text-left has-text-grey">${measure.legislature_name.length === 2 ? stateDistrict : firstChamber}</td>
               <td class="has-text-right">${constituent_yeas || 0}</td>
               <td class="has-text-right">${constituent_nays || 0}</td>
             </tr>


### PR DESCRIPTION
Currently state districts are displayed as below:

![image](https://user-images.githubusercontent.com/39286778/56393424-02e82f80-61fa-11e9-9b5e-4715c40b6cf8.png)

This modifies WIL77 to say WI A.D. 77, and similar language for other chambers, which is the more standard approach
![image](https://user-images.githubusercontent.com/39286778/56401517-da266100-621e-11e9-9e5f-ca599fe0ab24.png)

These changes should work for every state chamber in the US, including uni-chambers

Related to this older request, updated after code change
https://github.com/voteliquid/liquid.us/pull/104

