### PR TITLE
Removes unnecessary language, punctuation from titles

### DIFF
--- a/views/legislation-page.js
+++ b/views/legislation-page.js
@@ -1,5 +1,5 @@
 const { APP_NAME } = process.env
-const { html } = require('../helpers')
+const { html, capitalize } = require('../helpers')
 const activityIndicator = require('./activity-indicator')
 const stateNames = require('datasets-us-states-abbr-names')
 
@@ -189,7 +189,7 @@ const measureListRow = (s) => {
       <div class="card-content">
         <div class="columns">
           <div class="column">
-            <h3><a href="${measureUrl}">${titleRevised(s)}</a></h3>
+            <h3><a href="${measureUrl}">${simplifyTitle(s.title)}</a></h3>
             ${s.introduced_at ? html`
             <div class="is-size-7 has-text-grey">
               <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span> &mdash;
@@ -225,18 +225,10 @@ const measureListRow = (s) => {
   `
 }
 
-const titleRevised = (s) => {
-  if (s.title.includes('To amend ')) {
-    return `T${s.title.slice(s.title.indexOf(' to ') + 2)}`
-  } else if (s.title.includes(`(FE)`)) {
-     return `${s.title.charAt(13).toUpperCase() + s.title.slice(14, s.title.length - 6)}`
-  } else if (s.title.includes('Relating to: ')) {
-    return `${s.title.charAt(13).toUpperCase() + s.title.slice(14, s.title.length - 1)}`
-  } else if (s.title[s.title.length - 1] === '.') {
-    return s.title.slice(0, s.title.length - 1)
-  }
-    return s.title
+const simplifyTitle = (title) => {
+  return capitalize(title.replace(/^Relating to: /, ''))
 }
+
 const votePositionClass = (position) => {
   if (position === 'yea') return 'is-success'
   if (position === 'nay') return 'is-danger'

--- a/views/legislation-page.js
+++ b/views/legislation-page.js
@@ -189,7 +189,7 @@ const measureListRow = (s) => {
       <div class="card-content">
         <div class="columns">
           <div class="column">
-            <h3><a href="${measureUrl}">${s.title}</a></h3>
+            <h3><a href="${measureUrl}">${titleRevised(s)}</a></h3>
             ${s.introduced_at ? html`
             <div class="is-size-7 has-text-grey">
               <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span> &mdash;
@@ -225,6 +225,18 @@ const measureListRow = (s) => {
   `
 }
 
+const titleRevised = (s) => {
+  if (s.title.includes('To amend ')) {
+    return `T${s.title.slice(s.title.indexOf(' to ') + 2)}`
+  } else if (s.title.includes(`(FE)`)) {
+     return `${s.title.charAt(13).toUpperCase() + s.title.slice(14, s.title.length - 6)}`
+  } else if (s.title.includes('Relating to: ')) {
+    return `${s.title.charAt(13).toUpperCase() + s.title.slice(14, s.title.length - 1)}`
+  } else if (s.title[s.title.length - 1] === '.') {
+    return s.title.slice(0, s.title.length - 1)
+  }
+    return s.title
+}
 const votePositionClass = (position) => {
   if (position === 'yea') return 'is-success'
   if (position === 'nay') return 'is-danger'


### PR DESCRIPTION
Many bills have unnecessary language that only serves to confuse.

Congressional bills reference earlier bills with 'To amend'
![image](https://user-images.githubusercontent.com/39286778/56475750-610f4f80-6452-11e9-8a7b-015cd043c861.png)


WI bills have Related to and FE

![image](https://user-images.githubusercontent.com/39286778/56475746-49d06200-6452-11e9-971a-c54f452591e0.png)

WI and CA have periods at the end.

This pr changes all of those
![image](https://user-images.githubusercontent.com/39286778/56475759-72f0f280-6452-11e9-95c4-fbfd96f94172.png)

![image](https://user-images.githubusercontent.com/39286778/56475768-8f8d2a80-6452-11e9-8593-d5034711e205.png)
