### PR TITLE
Adds policy area links for each bill

### DIFF
--- a/models/measure.js
+++ b/models/measure.js
@@ -255,7 +255,6 @@ const fetchMeasures = (params, user) => (dispatch) => {
   if (user) fields.push('vote_position', 'delegate_rank', 'delegate_name')
   const url = `/measures_detailed?select=${fields.join(',')}${hide_direct_votes_params}${policy_area_query}${fts}${legislature}&type=not.eq.nomination${order}&limit=40`
 
-  console.log(url)
   return api(dispatch, url, { user })
     .then((measures) => dispatch({ type: 'measure:receivedList', measures }))
     .catch((error) => {

--- a/models/measure.js
+++ b/models/measure.js
@@ -242,6 +242,7 @@ const fetchMeasures = (params, user) => (dispatch) => {
 
   const hide_direct_votes = params.hide_direct_votes
   const hide_direct_votes_params = hide_direct_votes === 'on' ? '&or=(delegate_rank.is.null,delegate_rank.neq.-1)' : ''
+  const policy_area_query = params.policy_area ? `&policy_area=eq.${params.policy_area}` : ''
 
   const legislature = `&legislature_name=eq.${params.legislature || 'U.S. Congress'}`
 
@@ -252,8 +253,9 @@ const fetchMeasures = (params, user) => (dispatch) => {
     'summary', 'legislature_name', 'published', 'created_at', 'author_first_name', 'author_last_name', 'author_username', 'policy_area'
   ]
   if (user) fields.push('vote_position', 'delegate_rank', 'delegate_name')
-  const url = `/measures_detailed?select=${fields.join(',')}${hide_direct_votes_params}${fts}${legislature}&type=not.eq.nomination${order}&limit=40`
+  const url = `/measures_detailed?select=${fields.join(',')}${hide_direct_votes_params}${policy_area_query}${fts}${legislature}&type=not.eq.nomination${order}&limit=40`
 
+  console.log(url)
   return api(dispatch, url, { user })
     .then((measures) => dispatch({ type: 'measure:receivedList', measures }))
     .catch((error) => {

--- a/models/measure.js
+++ b/models/measure.js
@@ -249,7 +249,7 @@ const fetchMeasures = (params, user) => (dispatch) => {
     'title', 'number', 'type', 'short_id', 'id', 'status',
     'sponsor_username', 'sponsor_first_name', 'sponsor_last_name',
     'introduced_at', 'last_action_at', 'next_agenda_begins_at', 'next_agenda_action_at',
-    'summary', 'legislature_name', 'published', 'created_at', 'author_first_name', 'author_last_name', 'author_username',
+    'summary', 'legislature_name', 'published', 'created_at', 'author_first_name', 'author_last_name', 'author_username', 'policy_area'
   ]
   if (user) fields.push('vote_position', 'delegate_rank', 'delegate_name')
   const url = `/measures_detailed?select=${fields.join(',')}${hide_direct_votes_params}${fts}${legislature}&type=not.eq.nomination${order}&limit=40`

--- a/views/legislation-page.js
+++ b/views/legislation-page.js
@@ -195,7 +195,7 @@ const measureListRow = (s, url) => {
               <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span>
                 ${s.sponsor_first_name
                 ? html`&mdash; <a href=${`/${s.sponsor_username}`}>${s.sponsor_first_name} ${s.sponsor_last_name}</a> &bullet; <a href="${subjectUrl(url, s.policy_area)}">${s.policy_area}</a>${s.policy_area ? ' • ' : ''}${(new Date(s.introduced_at)).toLocaleDateString()}`
-                : html`—${(new Date(s.introduced_at)).toLocaleDateString()}`
+                : html`— Introduced on ${(new Date(s.introduced_at)).toLocaleDateString()}`
               }
               ${s.summary ? html`
                 <p class="is-hidden-tablet"><strong class="has-text-grey">Has summary</strong></p>

--- a/views/legislation-page.js
+++ b/views/legislation-page.js
@@ -192,18 +192,22 @@ const measureListRow = (s, url) => {
             <h3><a href="${measureUrl}">${s.title}</a></h3>
             ${s.introduced_at ? html`
             <div class="is-size-7 has-text-grey">
-              <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span>&mdash; 
-              ${s.sponsor_first_name
-              ? html`<a href=${`/${s.sponsor_username}`}>${s.sponsor_first_name} ${s.sponsor_last_name}</a> &bullet; <a href="${subjectUrl(url, s.policy_area)}">${s.policy_area}</a>${s.policy_area ? ' • ' : ''}${(new Date(s.introduced_at)).toLocaleDateString()}`
-              : html`Introduced on ${(new Date(s.introduced_at)).toLocaleDateString()}`
-              }
+              <p>
+                <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span> &bullet;
+                ${s.policy_area ? html`<a href="${subjectUrl(url, s.policy_area)}">${s.policy_area}</a> • ` : ''}
+                Introduced
+                ${s.sponsor_first_name ?
+                  html`by <a href=${`/${s.sponsor_username}`}>${s.sponsor_first_name} ${s.sponsor_last_name}</a>` : ''}
+                on ${(new Date(s.introduced_at)).toLocaleDateString()}
+              </p>
               ${s.summary ? html`
                 <p class="is-hidden-tablet"><strong class="has-text-grey">Has summary</strong></p>
               ` : ''}
               <p><strong class="has-text-grey">Status:</strong>
-              ${next_action_at ? html`
+                ${next_action_at ? html`
                 Scheduled for House floor action ${!s.next_agenda_action_at ? 'during the week of' : 'on'} ${new Date(next_action_at).toLocaleDateString()}
-              ` : s.status}</p>
+                ` : s.status}
+              </p>
               <p><strong class="has-text-grey">Last action:</strong> ${new Date(s.last_action_at).toLocaleDateString()}</p>
             </div>
             ` : html`

--- a/views/legislation-page.js
+++ b/views/legislation-page.js
@@ -90,7 +90,6 @@ const toggleDirectVotes = (cookies, dispatch) => (event) => {
 const updateFilter = (event, location, dispatch) => {
   event.preventDefault()
   const formData = require('parse-form').parse(event.target).body
-
   if (formData.legislature !== 'U.S. Congress') {
     formData.policy_area = '' // Only U.S. Congress has policy areas
   }
@@ -117,14 +116,14 @@ const filterForm = (geoip, legislatures, cookies, location, user, dispatch) => {
       <input name="policy_area" type="hidden" value="${location.query.policy_area}" />
       <input name="order" type="hidden" value="${location.query.order || 'upcoming'}" />
       <div class="field is-grouped is-grouped-right">
-        ${location.query.policy_area ?
-          html`<div class="control">
+        ${location.query.policy_area ? html`
+          <div class="control">
             <label class="checkbox has-text-grey">
               <input onclick=${removePolicyArea} type="checkbox" checked>
               ${location.query.policy_area.replace(/%20/g, ' ')}
             </label>
-          </div>`
-        : ''}
+          </div>
+        ` : ''}
         <div class="${`control ${user ? '' : 'is-hidden'}`}">
           <label class="checkbox has-text-grey">
             <input onclick=${toggleDirectVotes(cookies, dispatch)} type="checkbox" name="hide_direct_votes" checked=${!!hide_direct_votes}>
@@ -204,30 +203,35 @@ const measureListRow = (s, query) => {
           <div class="column">
             <h3><a href="${measureUrl}">${s.title}</a></h3>
             ${s.introduced_at ? html`
-            <div class="is-size-7 has-text-grey">
-              <p>
-                <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span> &bullet;
-                ${s.policy_area ? html`<a href=${`/legislation?${makeQuery({ policy_area: s.policy_area }, query)}`}>${s.policy_area}</a> • ` : ''}
-                Introduced
-                ${s.sponsor_first_name ?
-                  html`by <a href=${`/${s.sponsor_username}`}>${s.sponsor_first_name} ${s.sponsor_last_name}</a>` : ''}
-                on ${(new Date(s.introduced_at)).toLocaleDateString()}
-              </p>
-              ${s.summary ? html`
-                <p class="is-hidden-tablet"><strong class="has-text-grey">Has summary</strong></p>
-              ` : ''}
-              <p><strong class="has-text-grey">Status:</strong>
-                ${next_action_at ? html`
-                Scheduled for House floor action ${!s.next_agenda_action_at ? 'during the week of' : 'on'} ${new Date(next_action_at).toLocaleDateString()}
-                ` : s.status}
-              </p>
-              <p><strong class="has-text-grey">Last action:</strong> ${new Date(s.last_action_at).toLocaleDateString()}</p>
-            </div>
+              <div class="is-size-7 has-text-grey">
+                <p>
+                  <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span> &bullet;
+                  ${s.policy_area ? html`
+                    <a href=${`/legislation?${makeQuery({ policy_area: s.policy_area }, query)}`}>${s.policy_area}</a> •
+                  ` : ''}
+                  Introduced
+                  ${s.sponsor_first_name ? html`
+                    by <a href=${`/${s.sponsor_username}`}>${s.sponsor_first_name} ${s.sponsor_last_name}</a>
+                  ` : ''}
+                  on ${(new Date(s.introduced_at)).toLocaleDateString()}
+                </p>
+                ${s.summary ? html`
+                  <p class="is-hidden-tablet"><strong class="has-text-grey">Has summary</strong></p>
+                ` : ''}
+                <p>
+                  <strong class="has-text-grey">Status:</strong>
+                  ${next_action_at ? html`
+                    Scheduled for House floor action ${!s.next_agenda_action_at ? 'during the week of' : 'on'} ${new Date(next_action_at).toLocaleDateString()}
+                  ` : s.status}
+                </p>
+                <p><strong class="has-text-grey">Last action:</strong> ${new Date(s.last_action_at).toLocaleDateString()}</p>
+              </div>
             ` : html`
               <div class="is-size-7 has-text-grey">
                 ${s.author_username
                   ? html`Authored by <a href="${`/${s.author_username}`}">${s.author_first_name} ${s.author_last_name}</a>`
-                  : html`Authored by Anonymous`}
+                  : html`Authored by Anonymous`
+                }
                 on ${(new Date(s.created_at)).toLocaleDateString()}
               </div>
             `}
@@ -319,8 +323,8 @@ const makeQuery = (newFilters, oldQuery) => {
   }).join('&')
 }
 
-  const removePolicyArea = (event) => {
-    event.preventDefault()
-    document.querySelector('[name=policy_area]').value = ''
-    document.querySelector('.filter-submit').click()
-  }
+const removePolicyArea = (event) => {
+  event.preventDefault()
+  document.querySelector('[name=policy_area]').value = ''
+  document.querySelector('.filter-submit').click()
+}

--- a/views/legislation-page.js
+++ b/views/legislation-page.js
@@ -13,7 +13,7 @@ module.exports = (state, dispatch) => {
         <div class="has-text-right has-text-left-mobile">${proposeButton()}</div>
         ${filterTabs(state, dispatch)}
         ${loading.measures || !measuresByUrl[url] ? activityIndicator() :
-          (!measuresByUrl[url].length ? noBillsMsg(query.order, query) : measuresByUrl[url].map((shortId) => measureListRow(measures[shortId])))}
+          (!measuresByUrl[url].length ? noBillsMsg(query.order, query) : measuresByUrl[url].map((shortId) => measureListRow(measures[shortId], location.url)))}
         <style>
           .highlight-hover:hover {
             background: #f6f8fa;
@@ -180,7 +180,7 @@ const filterTabs = ({ geoip, legislatures, location, cookies, user }, dispatch) 
   `
 }
 
-const measureListRow = (s) => {
+const measureListRow = (s, url) => {
   const next_action_at = s.next_agenda_action_at || s.next_agenda_begins_at
   const measureUrl = s.author_username ? `/${s.author_username}/legislation/${s.short_id}` : `/legislation/${s.short_id}`
 
@@ -190,6 +190,9 @@ const measureListRow = (s) => {
         <div class="columns">
           <div class="column">
             <h3><a href="${measureUrl}">${s.title}</a></h3>
+            <div class="${s.policy_area ? 'is-size-7 has-text-grey' : 'is-hidden'}">
+              <b>Policy area:</b> <a href="${subjectUrl(url, s.policy_area)}">${s.policy_area}</a>
+            </div>
             ${s.introduced_at ? html`
             <div class="is-size-7 has-text-grey">
               <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span> &mdash;
@@ -231,6 +234,11 @@ const votePositionClass = (position) => {
   return ''
 }
 
+const subjectUrl = (url, policy_area) => {
+  if (url.includes('terms')) { return url.replace('&terms', `&policy_area=${policy_area}&terms`) }
+  if (url.includes('legislature')) { return url.replace('&legislature', `&policy_area=${policy_area}&legislature`) }
+  return `${url}?order=upcoming&policy_area=${policy_area}&legislature=U.S. Congress`
+}
 const voteButton = (s) => {
   let voteBtnTxt = 'Vote'
   let voteBtnClass = 'button is-small is-outlined is-primary'

--- a/views/legislation-page.js
+++ b/views/legislation-page.js
@@ -90,8 +90,9 @@ const toggleDirectVotes = (cookies, dispatch) => (event) => {
 const updateFilter = (event, location, dispatch) => {
   event.preventDefault()
   const formData = require('parse-form').parse(event.target).body
+
   if (formData.legislature !== 'U.S. Congress') {
-    formData.policy_area = ''
+    formData.policy_area = '' // Only U.S. Congress has policy areas
   }
   const formUrl = `${location.path}?${Object.keys(formData).map((key) => {
     return `${key}=${formData[key]}`
@@ -117,9 +118,9 @@ const filterForm = (geoip, legislatures, cookies, location, user, dispatch) => {
       <input name="order" type="hidden" value="${location.query.order || 'upcoming'}" />
       <div class="field is-grouped is-grouped-right">
         ${location.query.policy_area ?
-          html`<div class="${`control ${location.query.policy_area ? '' : 'is-hidden'}`}">
+          html`<div class="control">
             <label class="checkbox has-text-grey">
-              <input onclick=${removePolicyArea} type="checkbox" checked="true">
+              <input onclick=${removePolicyArea} type="checkbox" checked>
               ${location.query.policy_area.replace(/%20/g, ' ')}
             </label>
           </div>`

--- a/views/legislation-page.js
+++ b/views/legislation-page.js
@@ -192,10 +192,10 @@ const measureListRow = (s, url) => {
             <h3><a href="${measureUrl}">${s.title}</a></h3>
             ${s.introduced_at ? html`
             <div class="is-size-7 has-text-grey">
-              <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span>
-                ${s.sponsor_first_name
-                ? html`&mdash; <a href=${`/${s.sponsor_username}`}>${s.sponsor_first_name} ${s.sponsor_last_name}</a> &bullet; <a href="${subjectUrl(url, s.policy_area)}">${s.policy_area}</a>${s.policy_area ? ' • ' : ''}${(new Date(s.introduced_at)).toLocaleDateString()}`
-                : html`— Introduced on ${(new Date(s.introduced_at)).toLocaleDateString()}`
+              <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span>&mdash; 
+              ${s.sponsor_first_name
+              ? html`<a href=${`/${s.sponsor_username}`}>${s.sponsor_first_name} ${s.sponsor_last_name}</a> &bullet; <a href="${subjectUrl(url, s.policy_area)}">${s.policy_area}</a>${s.policy_area ? ' • ' : ''}${(new Date(s.introduced_at)).toLocaleDateString()}`
+              : html`Introduced on ${(new Date(s.introduced_at)).toLocaleDateString()}`
               }
               ${s.summary ? html`
                 <p class="is-hidden-tablet"><strong class="has-text-grey">Has summary</strong></p>

--- a/views/legislation-page.js
+++ b/views/legislation-page.js
@@ -190,15 +190,12 @@ const measureListRow = (s, url) => {
         <div class="columns">
           <div class="column">
             <h3><a href="${measureUrl}">${s.title}</a></h3>
-            <div class="${s.policy_area ? 'is-size-7 has-text-grey' : 'is-hidden'}">
-              <b>Policy area:</b> <a href="${subjectUrl(url, s.policy_area)}">${s.policy_area}</a>
-            </div>
             ${s.introduced_at ? html`
             <div class="is-size-7 has-text-grey">
-              <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span> &mdash;
-              ${s.sponsor_first_name
-                ? html`Introduced by&nbsp;<a href=${`/${s.sponsor_username}`}>${s.sponsor_first_name} ${s.sponsor_last_name}</a>&nbsp;on ${(new Date(s.introduced_at)).toLocaleDateString()}`
-                : html`Introduced on ${(new Date(s.introduced_at)).toLocaleDateString()}`
+              <span class="has-text-weight-bold">${s.short_id.replace(/^[^-]+-(\D+)(\d+)/, '$1 $2').toUpperCase()}</span>
+                ${s.sponsor_first_name
+                ? html`&mdash; <a href=${`/${s.sponsor_username}`}>${s.sponsor_first_name} ${s.sponsor_last_name}</a> &bullet; <a href="${subjectUrl(url, s.policy_area)}">${s.policy_area}</a>${s.policy_area ? ' • ' : ''}${(new Date(s.introduced_at)).toLocaleDateString()}`
+                : html`—${(new Date(s.introduced_at)).toLocaleDateString()}`
               }
               ${s.summary ? html`
                 <p class="is-hidden-tablet"><strong class="has-text-grey">Has summary</strong></p>

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -32,7 +32,7 @@ module.exports = (state, dispatch) => {
       ${panelTitleBlock('Votes')}
       ${measureVoteCounts({ measure, offices })}
       ${panelTitleBlock('Info')}
-      ${measureInfoPanel({ measure, showStatusTracker })}
+      ${measureInfoPanel({ measure, showStatusTracker }, state.location.url)}
       ${measureActionsPanel(state, dispatch)}
     </nav>
   `
@@ -85,7 +85,7 @@ const measureInfoPanel = ({ measure, showStatusTracker }) => {
   const {
     introduced_at, created_at, author_username, sponsor_username,
     sponsor_first_name, sponsor_last_name, author_first_name,
-    author_last_name, type, number, congress, chamber, legislature_name
+    author_last_name, type, number, congress, chamber, legislature_name, policy_area
   } = measure
 
   let bill_details_name = false
@@ -122,6 +122,14 @@ const measureInfoPanel = ({ measure, showStatusTracker }) => {
                 : author_username
                   ? html`<a href="${`/${author_username}`}">${author_first_name} ${author_last_name}</a>`
                   : ''}
+            </div>
+          </div>
+          <div class="${policy_area ? 'column is-one-third' : 'is-hidden'}">
+            <div class="has-text-grey">Subject</div>
+          </div>
+          <div class="${policy_area ? 'column is-two-thirds' : 'is-hidden'}">
+            <div class="has-text-right">
+              ${html`<a href="${`/legislation?order=upcoming&policy_area=${policy_area}`}">${policy_area}</a>`}
             </div>
           </div>
           ${bill_details_url ? html`

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -32,7 +32,7 @@ module.exports = (state, dispatch) => {
       ${panelTitleBlock('Votes')}
       ${measureVoteCounts({ measure, offices })}
       ${panelTitleBlock('Info')}
-      ${measureInfoPanel({ measure, showStatusTracker }, state.location.url)}
+      ${measureInfoPanel({ measure, showStatusTracker })}
       ${measureActionsPanel(state, dispatch)}
     </nav>
   `
@@ -124,14 +124,16 @@ const measureInfoPanel = ({ measure, showStatusTracker }) => {
                   : ''}
             </div>
           </div>
-          <div class="${policy_area ? 'column is-one-third' : 'is-hidden'}">
-            <div class="has-text-grey">Subject</div>
-          </div>
-          <div class="${policy_area ? 'column is-two-thirds' : 'is-hidden'}">
-            <div class="has-text-right">
-              ${html`<a href="${`/legislation?order=upcoming&policy_area=${policy_area}`}">${policy_area}</a>`}
+          ${policy_area ? html`
+            <div class="column is-one-third">
+              <div class="has-text-grey">Subject</div>
             </div>
-          </div>
+            <div class="column is-two-thirds">
+              <div class="has-text-right">
+                <a href="${`/legislation?policy_area=${policy_area}`}">${policy_area}</a>
+              </div>
+            </div>
+          ` : ''}
           ${bill_details_url ? html`
             <div class="column is-one-third"><div class="has-text-grey">Full text</div></div>
             <div class="column is-two-thirds">


### PR DESCRIPTION
Modified the first line under the bill page to include the policy area with a link
See sample link below
![image](https://user-images.githubusercontent.com/39286778/56930595-d0182400-6aa2-11e9-8f3a-4a16014b83cd.png)

Once clicked, adds policy_area= to url and modifies api filter to only show bills with that policy area
![image](https://user-images.githubusercontent.com/39286778/56930640-f3db6a00-6aa2-11e9-8704-75889c2a0971.png)

If no policy area, looks like this:
![image](https://user-images.githubusercontent.com/39286778/56930697-3d2bb980-6aa3-11e9-8860-c048639c073a.png)

