### PR TITLE
Replaces '%20' with ' ' when pulling leg name from url

### DIFF
--- a/views/legislation-page.js
+++ b/views/legislation-page.js
@@ -101,7 +101,7 @@ const filterForm = (geoip, legislatures, cookies, location, user, dispatch) => {
   const legislatureQuery = decodeURIComponent(location.query.legislature).replace(/\+/g, ' ')
 
   // Add legislature from URL to legislature selection
-  if (location.query.legislature && !legislatures.some(({ abbr }) => abbr === location.query.legislature)) {
+  if (location.query.legislature && !legislatures.some(({ abbr }) => abbr === location.query.legislature.replace(/%20/g, ' '))) {
     legislatures.push({
       abbr: location.query.legislature,
       name: stateNames[location.query.legislature] || location.query.legislature,


### PR DESCRIPTION
Currently, if you select Madison, WI and refresh, Liquid creates a fourth legislature Madison,%20WI
![image](https://user-images.githubusercontent.com/39286778/56988467-bd125c00-6b55-11e9-9db5-612c089f81aa.png)

This also happens if you click back to U.S. Congress and refresh

This pr changes the %20 with a space so that the fourth legislature doesn't show up.