### PR TITLE
Removes "" from Learn more link that was preventing it from working

### DIFF
--- a/views/measure-summary.js
+++ b/views/measure-summary.js
@@ -6,7 +6,7 @@ module.exports = (measure, dispatch) => {
   const index = short_id.indexOf('-')
   const bill_id = short_id.slice(index + 1)
   const summary = type === 'nomination' && measure.summary ? `Confirmation of ${measure.summary}` : linkifyUrls(measure.summary)
-  const link = measure.legislature_name === "U.S. Congress" ? `"https://www.congress.gov/bill/${congress}th-congress/${chamber === 'Lower' ? 'house' : 'senate'}-bill/${number}/text"` : measure.legislature_name === "WI" ? `https://docs.legis.wisconsin.gov/${congress}/proposals/reg/asm/bill/${bill_id}` : measure.legislature_name === "CA" ? `https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=${congress}0${bill_id.toUpperCase()}` : ''
+  const link = measure.legislature_name === "U.S. Congress" ? `https://www.congress.gov/bill/${congress}th-congress/${chamber === 'Lower' ? 'house' : 'senate'}-bill/${number}/text` : measure.legislature_name === "WI" ? `https://docs.legis.wisconsin.gov/${congress}/proposals/reg/asm/bill/${bill_id}` : measure.legislature_name === "CA" ? `https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=${congress}0${bill_id.toUpperCase()}` : ''
 
   const summaryLink =
     measure.author_id === null


### PR DESCRIPTION
Clicking Learn more on Congressional bill pages gets you here: https://liquid.us/legislation/%22"https://www.congress.gov/bill/116th-congress/house-bill/317/text%22"

![image](https://user-images.githubusercontent.com/39286778/56997191-94499100-6b6c-11e9-9a5d-856cdfa651a4.png)

This pr removes the "", making the link functional. I tested it successfully on the backend
