### PR TITLE
Clean Dane county bill page of incorrect info

### DIFF
--- a/models/measure.js
+++ b/models/measure.js
@@ -121,7 +121,7 @@ module.exports = (event, state) => {
         loading: { ...state.loading, page: isMeasureDetailPage(state.location.route) ? false : state.loading.page, measure: false },
         location: {
           ...state.location,
-          title: isMeasureDetailPage(state.location.route) ? `${event.measure.legislature_name}: ${event.measure.title}` : state.location.title,
+          title: isMeasureDetailPage(state.location.route) ? `${hideTargetReps ? '' : `${event.measure.legislature_name}: `}${event.measure.title}` : state.location.title,
           ogImage: isMeasureDetailPage(state.location.route) && measureOgImage(event.measure),
         },
         measures: {
@@ -352,6 +352,10 @@ const scrollVoteFormIntoView = () => {
 const isMeasureDetailPage = (route) => {
   return route === '/legislation/:shortId' || route === '/nominations/:shortId' || route === '/:username/legislation/:shortId' || route === '/:username/legislation/:shortId/edit'
 }
+
+const hideTargetReps = (l) => (
+  l.short_id === 'stop-227M-jail'
+)
 
 const measureOgImage = (measure) => {
   const dbImage = measure.image_name ? `${ASSETS_URL}/measure-images/${measure.image_name}` : ''

--- a/models/measure.js
+++ b/models/measure.js
@@ -121,7 +121,7 @@ module.exports = (event, state) => {
         loading: { ...state.loading, page: isMeasureDetailPage(state.location.route) ? false : state.loading.page, measure: false },
         location: {
           ...state.location,
-          title: isMeasureDetailPage(state.location.route) ? `${hideTargetReps ? '' : `${event.measure.legislature_name}: `}${event.measure.title}` : state.location.title,
+          title: isMeasureDetailPage(state.location.route) ? `${hideLegNameSocial ? '' : `${event.measure.legislature_name}: `}${event.measure.title}` : state.location.title,
           ogImage: isMeasureDetailPage(state.location.route) && measureOgImage(event.measure),
         },
         measures: {
@@ -353,7 +353,7 @@ const isMeasureDetailPage = (route) => {
   return route === '/legislation/:shortId' || route === '/nominations/:shortId' || route === '/:username/legislation/:shortId' || route === '/:username/legislation/:shortId/edit'
 }
 
-const hideTargetReps = (l) => (
+const hideLegNameSocial = (l) => (
   l.short_id === 'stop-227M-jail'
 )
 

--- a/views/endorsement-page.js
+++ b/views/endorsement-page.js
@@ -13,7 +13,7 @@ module.exports = (state, dispatch) => {
   const title = l.type === 'nomination' ? `Do you support ${l.title.replace(/\.$/, '')}?` : l.title
   const hideTargetReps = (l) => (
     l.author_username === 'councilmemberbas'
-    || l.short_id === 'stop-$148m-jail'
+    || l.short_id === 'stop-227M-jail'
   )
 
   return html`

--- a/views/endorsement-page.js
+++ b/views/endorsement-page.js
@@ -22,7 +22,7 @@ module.exports = (state, dispatch) => {
         <div class="columns">
           <div class="column">
             <h2 class="title has-text-weight-semibold is-2 has-text-centered has-text-dark">${title}</h2>
-            ${hideTargetReps(l) ? '' : targetReps({ measure, vote, ...state }, dispatch)}
+            ${hideTargetReps ? '' : targetReps({ measure, vote, ...state }, dispatch)}
             <div class="small-screens-only">
               ${endorsementCount(vote, 'small-screen')}
             </div>

--- a/views/endorsement-page.js
+++ b/views/endorsement-page.js
@@ -11,6 +11,10 @@ module.exports = (state, dispatch) => {
   const vote = votes[location.params.voteId]
   const l = measure
   const title = l.type === 'nomination' ? `Do you support ${l.title.replace(/\.$/, '')}?` : l.title
+  const hideTargetReps = (l) => (
+    l.author_username === 'councilmemberbas'
+    || l.short_id === 'stop-$148m-jail'
+  )
 
   return html`
     <section class="section">
@@ -18,7 +22,7 @@ module.exports = (state, dispatch) => {
         <div class="columns">
           <div class="column">
             <h2 class="title has-text-weight-semibold is-2 has-text-centered has-text-dark">${title}</h2>
-            ${l.author_username === 'councilmemberbas' ? '' : targetReps({ measure, vote, ...state }, dispatch)}
+            ${hideTargetReps(l) ? '' : targetReps({ measure, vote, ...state }, dispatch)}
             <div class="small-screens-only">
               ${endorsementCount(vote, 'small-screen')}
             </div>

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -15,7 +15,7 @@ module.exports = (state, dispatch) => {
   const measureUrl = l.author_username
     ? `/${l.author_username}/${l.type === 'nomination' ? 'nominations' : 'legislation'}/${l.short_id}`
     : `/${l.type === 'nomination' ? 'nominations' : 'legislation'}/${l.short_id}`
-  const hideTargetReps = (l) => (
+  const daneCheck = (l) => (
     l.short_id === 'stop-227M-jail'
   )
 
@@ -28,12 +28,12 @@ module.exports = (state, dispatch) => {
           </a>
         </h3>
         <h4 class="subtitle is-size-7 has-text-grey is-uppercase has-text-weight-semibold">
-          ${hideTargetReps ? 'Dane County' : stateNames[l.legislature_name] || l.legislature_name}
+          ${daneCheck ? 'Dane County' : stateNames[l.legislature_name] || l.legislature_name}
         </h4>
       </div>
-      ${reps && reps.length && !hideTargetReps ? measureRepsPanel({ measure, reps }) : ''}
+      ${reps && reps.length && !daneCheck ? measureRepsPanel({ measure, reps }) : ''}
       ${panelTitleBlock('Votes')}
-      ${measureVoteCounts({ measure, offices }, hideTargetReps)}
+      ${measureVoteCounts({ measure, offices }, daneCheck)}
       ${panelTitleBlock('Info')}
       ${measureInfoPanel({ measure, showStatusTracker })}
       ${measureActionsPanel(state, dispatch)}
@@ -152,7 +152,7 @@ const measureInfoPanel = ({ measure, showStatusTracker }) => {
   `
 }
 
-const measureVoteCounts = ({ measure, offices }, hideTargetReps) => {
+const measureVoteCounts = ({ measure, offices }, daneCheck) => {
   const {
     type, constituent_yeas, constituent_nays, yeas, nays,
     legislature_name, chamber, delegate_name, vote_position, short_id
@@ -197,11 +197,11 @@ const measureVoteCounts = ({ measure, offices }, hideTargetReps) => {
               <td class="has-text-right">Nay</td>
             </tr>
             <tr>
-              <td class="has-text-left has-text-grey">${hideTargetReps ? 'All Votes' : legislature_name.replace(' Congress', '')}</td>
+              <td class="has-text-left has-text-grey">${daneCheck ? 'All Votes' : legislature_name.replace(' Congress', '')}</td>
               <td class="has-text-right">${yeas || 0}</td>
               <td class="has-text-right">${nays || 0}</td>
             </tr>
-            ${offices.length && localLegislatureName && !hideTargetReps ? html`
+            ${offices.length && localLegislatureName && !daneCheck ? html`
             <tr>
               <td class="has-text-left has-text-grey">${districtName(measure, offices, localLegislatureName)}</td>
               <td class="has-text-right">${constituent_yeas || 0}</td>

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -28,7 +28,7 @@ module.exports = (state, dispatch) => {
           </a>
         </h3>
         <h4 class="subtitle is-size-7 has-text-grey is-uppercase has-text-weight-semibold">
-          ${stateNames[l.legislature_name] || l.legislature_name}
+          ${hideTargetReps ? 'Dane County' : stateNames[l.legislature_name] || l.legislature_name}
         </h4>
       </div>
       ${reps && reps.length && !hideTargetReps ? measureRepsPanel({ measure, reps }) : ''}

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -197,7 +197,7 @@ const measureVoteCounts = ({ measure, offices }, hideTargetReps) => {
               <td class="has-text-right">Nay</td>
             </tr>
             <tr>
-              <td class="has-text-left has-text-grey">${legislature_name.replace(' Congress', '')}</td>
+              <td class="has-text-left has-text-grey">${hideTargetReps ? 'All Votes' : legislature_name.replace(' Congress', '')}</td>
               <td class="has-text-right">${yeas || 0}</td>
               <td class="has-text-right">${nays || 0}</td>
             </tr>

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -15,6 +15,9 @@ module.exports = (state, dispatch) => {
   const measureUrl = l.author_username
     ? `/${l.author_username}/${l.type === 'nomination' ? 'nominations' : 'legislation'}/${l.short_id}`
     : `/${l.type === 'nomination' ? 'nominations' : 'legislation'}/${l.short_id}`
+  const hideTargetReps = (l) => (
+    l.short_id === 'stop-227M-jail'
+  )
 
   return html`
     <nav class="panel">
@@ -28,7 +31,7 @@ module.exports = (state, dispatch) => {
           ${stateNames[l.legislature_name] || l.legislature_name}
         </h4>
       </div>
-      ${reps && reps.length ? measureRepsPanel({ measure, reps }) : ''}
+      ${reps && reps.length && !hideTargetReps ? measureRepsPanel({ measure, reps }) : ''}
       ${panelTitleBlock('Votes')}
       ${measureVoteCounts({ measure, offices })}
       ${panelTitleBlock('Info')}

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -33,7 +33,7 @@ module.exports = (state, dispatch) => {
       </div>
       ${reps && reps.length && !daneCheck ? measureRepsPanel({ measure, reps }) : ''}
       ${panelTitleBlock('Votes')}
-      ${measureVoteCounts({ measure, offices }, daneCheck)}
+      ${measureVoteCounts({ measure, offices, daneCheck })}
       ${panelTitleBlock('Info')}
       ${measureInfoPanel({ measure, showStatusTracker })}
       ${measureActionsPanel(state, dispatch)}
@@ -152,7 +152,7 @@ const measureInfoPanel = ({ measure, showStatusTracker }) => {
   `
 }
 
-const measureVoteCounts = ({ measure, offices }, daneCheck) => {
+const measureVoteCounts = ({ measure, offices, daneCheck }) => {
   const {
     type, constituent_yeas, constituent_nays, yeas, nays,
     legislature_name, chamber, delegate_name, vote_position, short_id

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -33,7 +33,7 @@ module.exports = (state, dispatch) => {
       </div>
       ${reps && reps.length && !hideTargetReps ? measureRepsPanel({ measure, reps }) : ''}
       ${panelTitleBlock('Votes')}
-      ${measureVoteCounts({ measure, offices })}
+      ${measureVoteCounts({ measure, offices }, hideTargetReps)}
       ${panelTitleBlock('Info')}
       ${measureInfoPanel({ measure, showStatusTracker })}
       ${measureActionsPanel(state, dispatch)}
@@ -152,7 +152,7 @@ const measureInfoPanel = ({ measure, showStatusTracker }) => {
   `
 }
 
-const measureVoteCounts = ({ measure, offices }) => {
+const measureVoteCounts = ({ measure, offices }, hideTargetReps) => {
   const {
     type, constituent_yeas, constituent_nays, yeas, nays,
     legislature_name, chamber, delegate_name, vote_position, short_id
@@ -201,7 +201,7 @@ const measureVoteCounts = ({ measure, offices }) => {
               <td class="has-text-right">${yeas || 0}</td>
               <td class="has-text-right">${nays || 0}</td>
             </tr>
-            ${offices.length && localLegislatureName ? html`
+            ${offices.length && localLegislatureName && !hideTargetReps ? html`
             <tr>
               <td class="has-text-left has-text-grey">${districtName(measure, offices, localLegislatureName)}</td>
               <td class="has-text-right">${constituent_yeas || 0}</td>

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -8,6 +8,7 @@ const shareButtons = require('./measure-share-buttons')
 module.exports = (state, dispatch) => {
   const { measure, offices } = state
   const l = measure
+  if (l.short_id === 'stop-227m-jail') { l.legislature_name = 'Dane County' }
   const reps = state.reps.filter(({ chamber, legislature }) => {
     return chamber === l.chamber && (stateAbbr[legislature.name] || legislature.name) === l.legislature_name
   })
@@ -15,9 +16,6 @@ module.exports = (state, dispatch) => {
   const measureUrl = l.author_username
     ? `/${l.author_username}/${l.type === 'nomination' ? 'nominations' : 'legislation'}/${l.short_id}`
     : `/${l.type === 'nomination' ? 'nominations' : 'legislation'}/${l.short_id}`
-  const daneCheck = (l) => (
-    l.short_id === 'stop-227M-jail'
-  )
 
   return html`
     <nav class="panel">
@@ -28,12 +26,12 @@ module.exports = (state, dispatch) => {
           </a>
         </h3>
         <h4 class="subtitle is-size-7 has-text-grey is-uppercase has-text-weight-semibold">
-          ${daneCheck ? 'Dane County' : stateNames[l.legislature_name] || l.legislature_name}
+          ${stateNames[l.legislature_name] || l.legislature_name}
         </h4>
       </div>
-      ${reps && reps.length && !daneCheck ? measureRepsPanel({ measure, reps }) : ''}
+      ${reps && reps.length ? measureRepsPanel({ measure, reps }) : ''}
       ${panelTitleBlock('Votes')}
-      ${measureVoteCounts({ measure, offices, daneCheck })}
+      ${measureVoteCounts({ measure, offices })}
       ${panelTitleBlock('Info')}
       ${measureInfoPanel({ measure, showStatusTracker })}
       ${measureActionsPanel(state, dispatch)}
@@ -152,7 +150,7 @@ const measureInfoPanel = ({ measure, showStatusTracker }) => {
   `
 }
 
-const measureVoteCounts = ({ measure, offices, daneCheck }) => {
+const measureVoteCounts = ({ measure, offices }) => {
   const {
     type, constituent_yeas, constituent_nays, yeas, nays,
     legislature_name, chamber, delegate_name, vote_position, short_id
@@ -197,11 +195,11 @@ const measureVoteCounts = ({ measure, offices, daneCheck }) => {
               <td class="has-text-right">Nay</td>
             </tr>
             <tr>
-              <td class="has-text-left has-text-grey">${daneCheck ? 'All Votes' : legislature_name.replace(' Congress', '')}</td>
+              <td class="has-text-left has-text-grey">${legislature_name.replace(' Congress', '')}</td>
               <td class="has-text-right">${yeas || 0}</td>
               <td class="has-text-right">${nays || 0}</td>
             </tr>
-            ${offices.length && localLegislatureName && !daneCheck ? html`
+            ${offices.length && localLegislatureName ? html`
             <tr>
               <td class="has-text-left has-text-grey">${districtName(measure, offices, localLegislatureName)}</td>
               <td class="has-text-right">${constituent_yeas || 0}</td>


### PR DESCRIPTION
Overall, this PR aims to make it so that for the endorsement page, bill page and social for the bill below doesn't mention WI and references Dane county where applicable. 

https://liquid.us/dallascole/legislation/stop-227m-jail

David helped initially, including creating a function that checks for the short_id rather than doing so in the html. We also moved the existing check for councilmemberbas into that function

Specific changes: 
Bill page: 
- removed rep image and district results
- replaced WISCONSIN with DANE COUNTY
- replaced WI with 'Total Votes' for Liquid votes

Endorsement page:
- removed To legislature, reps bar

Social page:
- removed WI from before the measure title