### PR TITLE
Put Propose button into nav bar & remove from leg list page

### DIFF
--- a/views/legislation-page.js
+++ b/views/legislation-page.js
@@ -10,7 +10,6 @@ module.exports = (state, dispatch) => {
   return html`
     <div class="section">
       <div class="container is-widescreen">
-        <div class="has-text-right has-text-left-mobile">${proposeButton()}</div>
         ${filterTabs(state, dispatch)}
         ${loading.measures || !measuresByUrl[url] ? activityIndicator() :
           (!measuresByUrl[url].length ? noBillsMsg(query.order, query) : measuresByUrl[url].map((shortId) => measureListRow(measures[shortId], query)))}

--- a/views/navbar.js
+++ b/views/navbar.js
@@ -10,10 +10,6 @@ module.exports = ({ navbar: { hamburgerVisible }, location, search, user }, disp
           <a class="navbar-item" href="/">
             <img src="${APP_LOGO}" alt="${APP_NAME}" />
           </a>
-          <a class="button is-primary propose-button" style="margin-top: 1rem" href="/legislation/propose">
-            <span class="icon"><i class="fa fa-file"></i></span>
-            <span class="has-text-weight-semibold">Propose</span>
-          </a>
           <div role="button" href="#" aria-label="menu" aria-expanded="${hamburgerVisible ? 'true' : 'false'}" class="${`navbar-burger burger ${hamburgerVisible ? 'is-active' : ''}`}" onclick=${(event) => dispatch({ type: 'navHamburgerToggled', event })}>
             <span aria-hidden="true"></span>
             <span aria-hidden="true"></span>
@@ -21,7 +17,7 @@ module.exports = ({ navbar: { hamburgerVisible }, location, search, user }, disp
           </div>
         </div>
         <div class=${`navbar-menu ${hamburgerVisible ? 'is-active' : ''}`}>
-          <div class="navbar-item" style="flex-grow: 1; max-width: 500px;">
+          <div class="navbar-item" style="flex-grow: 1;">
             ${searchView(search, mapEvent('search', dispatch))}
           </div>
           <div class="navbar-end">
@@ -52,7 +48,7 @@ const style = `
   @media (max-width: 720px) {
     .navbar-brand .navbar-item img {
       margin: 4px 0;
-      max-height: 30px;
+      max-height: 40px;
       padding-left: 12px;
     }
     .navbar {
@@ -94,6 +90,10 @@ const navbarAuthed = ({ location, user }) => {
   const { path } = location
 
   return html`
+    <a class="button is-primary" style="margin-top: 1rem" href="/legislation/propose">
+      <span class="icon"><i class="fa fa-file"></i></span>
+      <span class="has-text-weight-semibold">Propose</span>
+    </a>
     <a class=${`navbar-item ${path.slice(0, 12) === '/legislation' ? 'is-active' : ''}`} href="/legislation">Browse</a>
     <div class="navbar-item has-dropdown is-hoverable">
       <a class="navbar-link" href="${username_url}">${user.first_name || 'You'}</a>

--- a/views/navbar.js
+++ b/views/navbar.js
@@ -55,7 +55,7 @@ const style = `
       padding: 0;
     }
     .propose-button {
-      max-height: 28px;
+      margin: 0 0 1 0
     }
     a.navbar-item:hover {
       background-color: #f5f5f5 !important;
@@ -90,10 +90,12 @@ const navbarAuthed = ({ location, user }) => {
   const { path } = location
 
   return html`
-    <a class="button is-primary" style="margin-top: 1rem" href="/legislation/propose">
-      <span class="icon"><i class="fa fa-file"></i></span>
-      <span class="has-text-weight-semibold">Propose</span>
-    </a>
+    <div class="buttons is-centered">
+      <a class="button is-primary" style="margin-top: 1.5rem" href="/legislation/propose">
+        <span class="icon"><i class="fa fa-file"></i></span>
+        <span class="has-text-weight-semibold">Propose</span>
+      </a>
+    </div>
     <a class=${`navbar-item ${path.slice(0, 12) === '/legislation' ? 'is-active' : ''}`} href="/legislation">Browse</a>
     <div class="navbar-item has-dropdown is-hoverable">
       <a class="navbar-link" href="${username_url}">${user.first_name || 'You'}</a>

--- a/views/navbar.js
+++ b/views/navbar.js
@@ -89,7 +89,10 @@ const navbarAuthed = ({ location, user }) => {
 
   return html`
     <a class=${`navbar-item ${path.slice(0, 12) === '/legislation' ? 'is-active' : ''}`} href="/legislation">Legislation</a>
-    <a class=${`navbar-item ${path.slice(0, 8) === '/proxies' ? 'is-active' : ''}`} href="/proxies">Your Proxies</a>
+    <a class="button is-primary" style="margin-top: 1rem;" href="/legislation/propose">
+      <span class="icon"><i class="fa fa-file"></i></span>
+      <span class="has-text-weight-semibold">Propose</span>
+    </a>
     <div class="navbar-item has-dropdown is-hoverable">
       <a class="navbar-link" href="${username_url}">${user.first_name || 'You'}</a>
       <div class="navbar-dropdown is-right">
@@ -99,9 +102,7 @@ const navbarAuthed = ({ location, user }) => {
             : ''
         }
         <a class=${`navbar-item ${path === username_url ? 'is-active' : ''}`} href=${username_url}>Profile</a>
-        ${user.username
-          ? html`<a class=${`navbar-item ${path === '/edit_profile' ? 'is-active' : ''}`} href="/edit_profile">Edit Profile</a>`
-          : ''}
+        <a class=${`navbar-item ${path.slice(0, 8) === '/proxies' ? 'is-active' : ''}`} href="/proxies">Your Proxies</a>
         <a class=${`navbar-item ${path === `/legislation/yours` ? 'is-active' : ''}`} href="/legislation/yours">Proposed Legislation</a>
         <a class=${`navbar-item ${path === '/settings' ? 'is-active' : ''}`} href="/settings">Settings</a>
         <a class=${`navbar-item ${path === '/sign_out' ? 'is-active' : ''}`} href=${`${WWW_URL}/sign_out`}>Sign out</a>

--- a/views/navbar.js
+++ b/views/navbar.js
@@ -10,7 +10,10 @@ module.exports = ({ navbar: { hamburgerVisible }, location, search, user }, disp
           <a class="navbar-item" href="/">
             <img src="${APP_LOGO}" alt="${APP_NAME}" />
           </a>
-
+          <a class="button is-primary propose-button" style="margin-top: 1rem" href="/legislation/propose">
+            <span class="icon"><i class="fa fa-file"></i></span>
+            <span class="has-text-weight-semibold">Propose</span>
+          </a>
           <div role="button" href="#" aria-label="menu" aria-expanded="${hamburgerVisible ? 'true' : 'false'}" class="${`navbar-burger burger ${hamburgerVisible ? 'is-active' : ''}`}" onclick=${(event) => dispatch({ type: 'navHamburgerToggled', event })}>
             <span aria-hidden="true"></span>
             <span aria-hidden="true"></span>
@@ -18,7 +21,7 @@ module.exports = ({ navbar: { hamburgerVisible }, location, search, user }, disp
           </div>
         </div>
         <div class=${`navbar-menu ${hamburgerVisible ? 'is-active' : ''}`}>
-          <div class="navbar-item" style="flex-grow: 1;">
+          <div class="navbar-item" style="flex-grow: 1; max-width: 500px;">
             ${searchView(search, mapEvent('search', dispatch))}
           </div>
           <div class="navbar-end">
@@ -49,11 +52,14 @@ const style = `
   @media (max-width: 720px) {
     .navbar-brand .navbar-item img {
       margin: 4px 0;
-      max-height: 40px;
+      max-height: 30px;
       padding-left: 12px;
     }
     .navbar {
       padding: 0;
+    }
+    .propose-button {
+      max-height: 28px;
     }
     a.navbar-item:hover {
       background-color: #f5f5f5 !important;
@@ -89,10 +95,6 @@ const navbarAuthed = ({ location, user }) => {
 
   return html`
     <a class=${`navbar-item ${path.slice(0, 12) === '/legislation' ? 'is-active' : ''}`} href="/legislation">Browse</a>
-    <a class="button is-primary" style="margin-top: 1rem;" href="/legislation/propose">
-      <span class="icon"><i class="fa fa-file"></i></span>
-      <span class="has-text-weight-semibold">Propose</span>
-    </a>
     <div class="navbar-item has-dropdown is-hoverable">
       <a class="navbar-link" href="${username_url}">${user.first_name || 'You'}</a>
       <div class="navbar-dropdown is-right">

--- a/views/navbar.js
+++ b/views/navbar.js
@@ -88,7 +88,7 @@ const navbarAuthed = ({ location, user }) => {
   const { path } = location
 
   return html`
-    <a class=${`navbar-item ${path.slice(0, 12) === '/legislation' ? 'is-active' : ''}`} href="/legislation">Legislation</a>
+    <a class=${`navbar-item ${path.slice(0, 12) === '/legislation' ? 'is-active' : ''}`} href="/legislation">Browse</a>
     <a class="button is-primary" style="margin-top: 1rem;" href="/legislation/propose">
       <span class="icon"><i class="fa fa-file"></i></span>
       <span class="has-text-weight-semibold">Propose</span>


### PR DESCRIPTION
We want people to be able to have the option to propose wherever they are on the site. I've left it on the Proposed legislation page for now as the button is a different style and makes sense in context

Also modifies Legislation to Browse after discussion with David

I modified the original spec a little bit from: 
![image](https://user-images.githubusercontent.com/39286778/57945841-84d28380-78a0-11e9-9b2f-a841d729d683.png)
to 
![image](https://user-images.githubusercontent.com/39286778/57945726-39b87080-78a0-11e9-9216-f8368a96025c.png)

I did this for three reasons

- To keep Search and browse next to each other
- To make it possible to show the propose button on mobile
![image](https://user-images.githubusercontent.com/39286778/57946186-55704680-78a1-11e9-9c59-755bc2d37639.png)

- I think it looks better to have more space around the propose button 

I can't figure out how to make the Propose button, search, bar and browse space apart evenly from each other
![image](https://user-images.githubusercontent.com/39286778/57946205-628d3580-78a1-11e9-9264-d1d767de6771.png)

