### PR TITLE
Update short_id for Dane County jail bill

### DIFF
--- a/models/measure.js
+++ b/models/measure.js
@@ -354,7 +354,7 @@ const isMeasureDetailPage = (route) => {
 }
 
 const hideLegNameSocial = (l) => (
-  l.short_id === 'stop-227M-jail'
+  l.short_id === 'press-pause-on-227m-new-jail'
 )
 
 const measureOgImage = (measure) => {

--- a/views/endorsement-page.js
+++ b/views/endorsement-page.js
@@ -13,7 +13,7 @@ module.exports = (state, dispatch) => {
   const title = l.type === 'nomination' ? `Do you support ${l.title.replace(/\.$/, '')}?` : l.title
   const hideTargetReps = (l) => (
     l.author_username === 'councilmemberbas'
-    || l.short_id === 'stop-227M-jail'
+    || l.short_id === 'press-pause-on-227m-new-jail'
   )
 
   return html`

--- a/views/measure-sidebar.js
+++ b/views/measure-sidebar.js
@@ -8,7 +8,7 @@ const shareButtons = require('./measure-share-buttons')
 module.exports = (state, dispatch) => {
   const { measure, offices } = state
   const l = measure
-  if (l.short_id === 'stop-227m-jail') { l.legislature_name = 'Dane County' }
+  if (l.short_id === 'press-pause-on-227m-new-jail') { l.legislature_name = 'Dane County' }
   const reps = state.reps.filter(({ chamber, legislature }) => {
     return chamber === l.chamber && (stateAbbr[legislature.name] || legislature.name) === l.legislature_name
   })


### PR DESCRIPTION
This pr updates the checks for stop-227M-jail to instead look for press-pause-on-227m-new-jail

I've confirmed that it works on bill and comment page.

I have a bigger pr that creates a new To bar, but if we can't get that one done, we should at least do this one
https://github.com/voteliquid/liquid.us/pull/132