### PR TITLE
Update decarceratedane page to remove committee references

### DIFF
--- a/views/dane-county-targetReps.js
+++ b/views/dane-county-targetReps.js
@@ -3,7 +3,6 @@ const { html } = require('../helpers')
 
 module.exports = ({ vote, user }) => {
   const measureImage = `${ASSETS_URL}/legislature-images/Dane County.png`
-  const chairImage = `${ASSETS_URL}/Patrick-Miles.png`
   const reply = (vote.replies || []).filter(({ user_id }) => (user && user.id === user_id))[0]
   return html`
     <br />
@@ -24,27 +23,12 @@ module.exports = ({ vote, user }) => {
           </div>
         </div>
       </div>
-
-      <div class="column">
-        <div class="media">
-          <div class="media-left">
-            <div class="image is-48x48 is-clipped">
-              <img src=${chairImage} style="background: hsla(0, 0%, 87%, 0.5); padding: 4px;"/>
-            </div>
-          </div>
-          <div class="media-content has-text-weight-semibold is-size-5" style="line-height: 24px;">
-            Patrick Miles, Chair<br />
-            Personnel & Finance Committee
-          </div>
-        </div>
-      </div>
     </div>
     ${reply ? html`
       <div class="is-size-5 box">
         <p>Your comment will be sent to your legislators, but you should email them directly at <a href="mailto:county_board_recipients@countyofdane.com" target="_blank">county_board_recipients@countyofdane.com</a> or attend one of the meetings below to emphasize the importance of this issue:</p>
         <br />
         <p><a href="https://goo.gl/maps/kQWbRGMjhS6sMpuXA" target="_blank">City County Building, 210 MLK Jr Blvd, Madison, WI, 53703</a></p>
-        <p><b>May 28, 2019</b> 5:30pm in room 201, Personnel & Finance Committee</p>
         <p><b>June 6, 2019</b> 7:00pm in room 201, Dane County Board of Supervisors vote</p>
         <br />
         <p><em>We will provide an update as the meeting dates are confirmed.</em></p>

--- a/views/dane-county-targetReps.js
+++ b/views/dane-county-targetReps.js
@@ -26,7 +26,7 @@ module.exports = ({ vote, user }) => {
     </div>
     ${reply ? html`
       <div class="is-size-5 box">
-        <p>Your comment will be sent to your legislators, but you should email them directly at <a href="mailto:county_board_recipients@countyofdane.com" target="_blank">county_board_recipients@countyofdane.com</a> or attend one of the meetings below to emphasize the importance of this issue:</p>
+        <p>Your comment will be sent to your legislators, but you should email them directly at <a href="mailto:county_board_recipients@countyofdane.com" target="_blank">county_board_recipients@countyofdane.com</a> or attend the June 6th Board meeting to emphasize the importance of this issue:</p>
         <br />
         <p><a href="https://goo.gl/maps/kQWbRGMjhS6sMpuXA" target="_blank">City County Building, 210 MLK Jr Blvd, Madison, WI, 53703</a></p>
         <p><b>June 6, 2019</b> 7:00pm in room 201, Dane County Board of Supervisors vote</p>


### PR DESCRIPTION
The committee meeting happened on Tuesday, so this information is no longer relevant.

I removed Patrick Miles, Chair of the Personnel & Finance committee from the To: section and took out the line about committee meeting info that shows up in the post-endorse message

