### PR TITLE
Improve already voted sidebar language: proxy vs nonproxy, voted differently

### DIFF
--- a/views/endorsement-page-sidebar.js
+++ b/views/endorsement-page-sidebar.js
@@ -77,7 +77,7 @@ module.exports = (state, dispatch) => {
 const endorsedPositionNotVote = (measure) => {
   let previousVote = 'voted yes'
   if (measure.vote_position === 'nay') { previousVote = 'voted no' }
-  if (measure.vote_position === 'abstained') { previousVote = html`abstained <span class="has-text-weight-normal">on</span>` }
+  if (measure.vote_position === 'abstained') { previousVote = 'abstained' }
 
 const userCommented = measure.comment ? 'and added your own argument' : 'and may have already backed an argument'
 const voteHistoryText = measure.delegate_name ? html`

--- a/views/endorsement-page-sidebar.js
+++ b/views/endorsement-page-sidebar.js
@@ -23,7 +23,7 @@ module.exports = (state, dispatch) => {
       <div class="${vote.showMobileEndorsementForm ? 'modal-content' : ''}">
         ${user && measure.vote_position && measure.vote_position !== vote.position
           // logged in, voted differently
-          ? endorsedOpposingPosition(measure)
+          ? endorsedOpposingPosition(measure, vote)
           : user && measure.vote_position && !vote.endorsed
           ? endorsedPositionNotVote(measure)
           : ''
@@ -81,10 +81,10 @@ const endorsedPositionNotVote = (measure) => {
 
 const userCommented = measure.comment ? 'and added your own argument' : 'and may have already backed an argument'
 const voteHistoryText = measure.delegate_name ? html`
-  Your proxy, ${measure.delegate_name}, has already <strong>${previousVote}</strong> on the underlying measure and may have included an argument.<br /><br />
+  Your proxy, ${measure.delegate_name}, has already <strong>${previousVote}</strong> on this item and may have included an argument.<br /><br />
   Endorse to back this argument instead.`
   : html`
-  You previously <strong>${previousVote}</strong> on the underlying measure ${userCommented}.<br /><br />
+  You previously <strong>${previousVote}</strong> on this item ${userCommented}.<br /><br />
   Endorse to back this argument instead.
 `
   return html`
@@ -93,7 +93,7 @@ const voteHistoryText = measure.delegate_name ? html`
     </div>
   `
 }
-const endorsedOpposingPosition = (measure) => {
+const endorsedOpposingPosition = (measure, vote) => {
   let previousVote = 'endorsed'
   if (measure.vote_position === 'nay') { previousVote = 'opposed' }
   if (measure.vote_position === 'abstain') { previousVote = html`abstained <span class="has-text-weight-normal">on</span>` }
@@ -102,7 +102,7 @@ const endorsedOpposingPosition = (measure) => {
   return html`
     <div class="notification is-warning is-marginless is-size-7">
       You${proxyVote} previously <strong>${previousVote}</strong> this item.<br /><br />
-      This will switch your vote.
+      This will switch your vote from ${measure.vote_position} to ${vote.position}.
     </div>
   `
 }

--- a/views/endorsement-page-sidebar.js
+++ b/views/endorsement-page-sidebar.js
@@ -21,9 +21,12 @@ module.exports = (state, dispatch) => {
     <div style="z-index: 30;" class=${`${vote.showMobileEndorsementForm ? 'modal is-active' : 'not-modal'} mobile-only`}>
       <div class="${vote.showMobileEndorsementForm ? 'modal-background' : ''}" onclick=${(event) => dispatch({ type: 'vote:toggledMobileEndorsementForm', vote, event })}></div>
       <div class="${vote.showMobileEndorsementForm ? 'modal-content' : ''}">
-        ${user && measure.vote_position && !vote.endorsed
+        ${user && measure.vote_position && measure.vote_position !== vote.position
           // logged in, voted differently
-          ? votedDifferentlyMessage(measure) : ''
+          ? endorsedOpposingPosition(measure)
+          : user && measure.vote_position && !vote.endorsed
+          ? endorsedPositionNotVote(measure)
+          : ''
         }
         <nav class="box">
           ${endorsementCount(vote)}
@@ -71,14 +74,34 @@ module.exports = (state, dispatch) => {
   `
 }
 
-const votedDifferentlyMessage = (measure) => {
+const endorsedPositionNotVote = (measure) => {
+  let previousVote = 'voted yes'
+  if (measure.vote_position === 'nay') { previousVote = 'voted no' }
+  if (measure.vote_position === 'abstained') { previousVote = html`abstained <span class="has-text-weight-normal">on</span>` }
+
+const userCommented = measure.comment ? 'and added your own argument' : 'and may have already backed an argument'
+const voteHistoryText = measure.delegate_name ? html`
+  Your proxy, ${measure.delegate_name}, has already <strong>${previousVote}</strong> on the underlying measure and may have included an argument.<br /><br />
+  Endorse to back this argument instead.`
+  : html`
+  You previously <strong>${previousVote}</strong> on the underlying measure ${userCommented}.<br /><br />
+  Endorse to back this argument instead.
+`
+  return html`
+    <div class="notification is-warning is-marginless is-size-7">
+      ${voteHistoryText}
+    </div>
+  `
+}
+const endorsedOpposingPosition = (measure) => {
   let previousVote = 'endorsed'
   if (measure.vote_position === 'nay') { previousVote = 'opposed' }
   if (measure.vote_position === 'abstain') { previousVote = html`abstained <span class="has-text-weight-normal">on</span>` }
+  const proxyVote = measure.delegate_rank !== -1 ? `r proxy, ${measure.delegate_name},` : ''
 
   return html`
     <div class="notification is-warning is-marginless is-size-7">
-      You previously <strong>${previousVote}</strong> this item.<br />
+      You${proxyVote} previously <strong>${previousVote}</strong> this item.<br /><br />
       This will switch your vote.
     </div>
   `


### PR DESCRIPTION
The current language alerting people that they've voted is always the same, but is only accurate some of the time

![image](https://user-images.githubusercontent.com/39286778/59566399-743f3580-9025-11e9-9c81-d1fc60fd20bd.png)

I left this language when they previously voted directly on a bill and the argument that they're looking at takes a different position (previously aye, this argument says no or abstain, etc)

I created a different case for:

Proxy voted; different position
![image](https://user-images.githubusercontent.com/39286778/59566570-8621d800-9027-11e9-91e6-3ffff480cf01.png)

Proxy voted; same position, different argument
![image](https://user-images.githubusercontent.com/39286778/59566684-f0874800-9028-11e9-8c5c-47a61881255c.png)

Directly voted; same position, commented
![image](https://user-images.githubusercontent.com/39286778/59566652-95555580-9028-11e9-9cca-d162a4432984.png)

Directly voted; same position, no comment
![image](https://user-images.githubusercontent.com/39286778/59566371-1ad70680-9025-11e9-9cac-85055b5559be.png)
