### PR TITLE
Make fourth legislature work by moving to separate function

### DIFF
--- a/views/edit-legislation-form.js
+++ b/views/edit-legislation-form.js
@@ -24,7 +24,7 @@ module.exports = (state, dispatch) => {
               <option value="${l1.id}" selected=${l1.abbr === legislature_name}>${l1.name}</option>
               <option value="${l2.id}" selected=${l2.abbr === legislature_name}>${l2.name}</option>
               <option value="${l3.id}" selected=${l3.abbr === legislature_name}>${l3.name}</option>
-              ${l4 ? `<option value="${l4.id}" selected=${l4.abbr === legislature_name}>${l4.name}</option>` : ''}
+              ${l4 ? fourthLegislature(l4, legislature_name) : ''}
             </select>
           </div>
         </div>
@@ -67,4 +67,10 @@ module.exports = (state, dispatch) => {
 
 const editedShortId = (dispatch) => (event) => {
   dispatch({ type: 'measure:editFormShortIdChanged', shortId: event.currentTarget.value, event })
+}
+
+const fourthLegislature = (l4, legislature_name) => {
+  return html`
+    <option value="${l4.id}" selected=${l4.abbr === legislature_name}>${l4.name}</option>
+  `
 }


### PR DESCRIPTION
This pr creates a fourthLegislature function that only activates when there's a forth legislature

![image](https://user-images.githubusercontent.com/39286778/61223543-78bd4380-a6e2-11e9-8917-ae8b6c4a16b7.png)

For some reason, the fourth legislature isn't working with the last round of fixes - not sure if I screwed it up initially by forgetting to check it was functional before submitting the pr or other changes, but this fixes it
