### PR TITLE
Allow users to delete proposals

### DIFF
--- a/models/measure.js
+++ b/models/measure.js
@@ -141,6 +141,9 @@ module.exports = (event, state) => {
           return votes
         }, state.votes),
       }, changePageTitle(isMeasureDetailPage(state.location.route) ? `${event.measure.legislature_name}: ${event.measure.title}` : state.location.title)]
+    case 'measure:measureDeleted':
+    console.log('is this happening')
+      return [state, combineEffects([preventDefault(event.event), deleteMeasure(state)])]
     case 'measure:votesReceived':
       return [{
         ...state,
@@ -364,4 +367,19 @@ const measureOgImage = (measure) => {
   const inlineImage = inlineImageMatch && inlineImageMatch[0]
   const measureImage = !isCity ? `${ASSETS_URL}/legislature-images/${measure.legislature_name}.png` : ''
   return dbImage || inlineImage || measureImage
+}
+const deleteMeasure = (state) => (dispatch) => {
+  const { user } = state
+
+  const measure = state.measures[state.location.params.shortId]
+  if (!window.confirm(`Are you sure you want to remove ${measure.title}?`)) return
+
+  return api(dispatch, `/measures?id=eq.${measure.id}`, {
+    method: 'DELETE',
+    user,
+  })
+  .then(() => {
+    return [state, redirect(`/${user.username}`)]
+  })
+  .catch(handleError(dispatch))
 }

--- a/views/edit-legislation-form.js
+++ b/views/edit-legislation-form.js
@@ -64,10 +64,12 @@ module.exports = (state, dispatch) => {
             </div>
           </div>
         </div>
+      </form>
+      <form method="POST" onsubmit="${handleForm(dispatch, { type: 'measure:measureDeleted' })}">
         <div class="column">
           <div class="field is-grouped">
             <div class="control">
-              <button class=${`button is-danger ${loading.editMeasure === 'saving' ? 'is-loading' : ''}`} disabled="${loading.editMeasure}" type="submit">
+              <button  class="button is-danger" type="submit" title="delete">
                 <span class="icon"><i class="fa fa-trash"></i></span>
                 <span>Delete</span>
               </button>

--- a/views/edit-legislation-form.js
+++ b/views/edit-legislation-form.js
@@ -53,12 +53,26 @@ module.exports = (state, dispatch) => {
           <p class="help">You can continue to edit your proposed bill later.</p>
         </div>
       </div>
-      <div class="field is-grouped">
-        <div class="control">
-          <button class=${`button is-primary ${loading.editMeasure === 'saving' ? 'is-loading' : ''}`} disabled="${loading.editMeasure}" type="submit">
-            <span class="icon"><i class="fa fa-edit"></i></span>
-            <span>Save</span>
-          </button>
+      <div class="columns">
+        <div class="column is-narrow">
+          <div class="field is-grouped">
+            <div class="control">
+              <button class=${`button is-primary ${loading.editMeasure === 'saving' ? 'is-loading' : ''}`} disabled="${loading.editMeasure}" type="submit">
+                <span class="icon"><i class="fa fa-edit"></i></span>
+                <span>Save</span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="column">
+          <div class="field is-grouped">
+            <div class="control">
+              <button class=${`button is-danger ${loading.editMeasure === 'saving' ? 'is-loading' : ''}`} disabled="${loading.editMeasure}" type="submit">
+                <span class="icon"><i class="fa fa-trash"></i></span>
+                <span>Delete</span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </form>


### PR DESCRIPTION
Created 'Delete' button and got it to where we need backend changes; specifically changing the relations for the measures table.

![image](https://user-images.githubusercontent.com/39286778/61407710-fb413100-a8a3-11e9-888d-25b730e3a159.png)

It's also possible my approach for deleting proposals doesn't work. I replicated the method from deleting proxies. This means calling a case that does the following with the api:
![image](https://user-images.githubusercontent.com/39286778/61407673-e82e6100-a8a3-11e9-8e40-b51e7a76d8b2.png)
