### PR TITLE
Sets default votes to private in accordance with our community policy

### DIFF
--- a/views/endorsement-signup-form.js
+++ b/views/endorsement-signup-form.js
@@ -49,7 +49,7 @@ module.exports = (state, dispatch) => {
       <div class="field">
         <div class="control">
           <label class="checkbox">
-            <input name="is_public" type="checkbox" checked />
+            <input name="is_public" type="checkbox" />
             Share my name publicly
           </label>
         </div>

--- a/views/measure-vote-form.js
+++ b/views/measure-vote-form.js
@@ -3,7 +3,7 @@ const { handleForm, html } = require('../helpers')
 module.exports = (state, dispatch) => {
   const { error, loading, location, measure: l, votes, user } = state
   const v = l.votes.filter((id) => (user && votes[id] && votes[id].user_id === user.id)).map((id) => votes[id])[0] || {}
-  const public_checked = v.hasOwnProperty('public') ? v.public : (!user || user.last_vote_public)
+  const public_checked = v.hasOwnProperty('public') ? v.public : (user && user.last_vote_public)
   const vote_position = v.vote_position || l.vote_position
   return html`
     <form method="POST" style="margin-bottom: 2rem;" onsubmit=${handleForm(dispatch, { type: 'vote:voted', measure: l })} onconnected=${scrollToForm(location)}>


### PR DESCRIPTION
Our community policy specifies that all votes are set to private to default. However, if you go to our petition or measure pages when logged out, the checkbox and dropdown both start as public

This pr changes it so that both are private by default
![image](https://user-images.githubusercontent.com/39286778/61409444-df3f8e80-a8a7-11e9-8351-0b3e6a954313.png)
![image](https://user-images.githubusercontent.com/39286778/61409468-e9fa2380-a8a7-11e9-87f2-6966301e0221.png)
