### PR TITLE
Hides targetReps bar if legislature name equals Madison, WI

### DIFF
--- a/views/endorsement-page.js
+++ b/views/endorsement-page.js
@@ -14,7 +14,7 @@ module.exports = (state, dispatch) => {
   const l = measure
   const title = l.type === 'nomination' ? `Do you support ${l.title.replace(/\.$/, '')}?` : l.title
   const hideTargetReps = (l) => (
-    l.author_username === 'councilmemberbas'
+    l.author_username === 'councilmemberbas' || l.legislature_name === 'Madison, WI'
   )
   const isDane = (l) => (
     l.short_id === 'press-pause-on-227m-new-jail'


### PR DESCRIPTION
We still have the wrong City Council names and there's a bug making each member show up twice. This hides the target Reps bar as a temporary measure until we fix those issues.

![image](https://user-images.githubusercontent.com/39286778/61808146-7c4a7c00-ae00-11e9-95d0-2ea6df6f40cd.png)
