### PR TITLE
Fix checks that relied on legislature_name being abbreviations

### DIFF
--- a/views/endorsement-page.js
+++ b/views/endorsement-page.js
@@ -178,7 +178,7 @@ const legislature = (measure) => {
           </div>
         </div>
         <div class="media-content has-text-weight-semibold is-size-5" style="line-height: 24px;">
-          ${name}<br />
+          ${measure.legislature_name}<br />
           ${measure.legislature_name === 'U.S. Congress' ? '' : 'Legislature'}
         </div>
       </div>

--- a/views/endorsement-page.js
+++ b/views/endorsement-page.js
@@ -3,7 +3,7 @@ const { avatarURL, html, linkifyUrls } = require('../helpers')
 const endorsementCount = require('./endorsement-count')
 const measureSummary = require('./measure-summary')
 const sidebar = require('./endorsement-page-sidebar')
-const stateNames = require('datasets-us-states-abbr-names')
+const stateAbbreviations = require('datasets-us-states-names-abbr')
 const daneTargetReps = require('./dane-county-targetReps')
 const petitionQuestions = require('./endorsement-questions')
 
@@ -166,9 +166,8 @@ const rep = (r) => {
 }
 
 const legislature = (measure) => {
-  const notLocal = measure.legislature_name.length === 2 || measure.legislature_name === 'U.S. Congress'
-  const measureImage = notLocal ? `${ASSETS_URL}/legislature-images/${measure.legislature_name}.png` : `${ASSETS_URL}/legislature-images/local.png`
-  const name = measure.legislature_name.length === 2 ? stateNames[measure.legislature_name] : measure.legislature_name
+  const local = measure.legislature_name.includes(',') || measure.legislature_name.includes('County')
+  const measureImage = local ? `${ASSETS_URL}/legislature-images/local.png` : `${ASSETS_URL}/legislature-images/${stateAbbreviations[measure.legislature_name]}.png`
 
   return html`
     <div class="column">
@@ -190,7 +189,7 @@ const legislature = (measure) => {
 const endorsementComment = (measure, vote) => {
   const { endorsed_vote, fullname, username, twitter_username } = vote
   const anonymousName = measure
-    ? `${measure.legislature_name === 'U.S. Congress' ? 'American' : (stateNames[measure.legislature_name] || measure.legislature_name)} Resident`
+    ? `${measure.legislature_name === 'U.S. Congress' ? 'American' : measure.legislature_name} Resident`
     : 'Anonymous'
   return html`
     <div class="comment">


### PR DESCRIPTION
I noticed that measure.legislature_name for state bills now generates the full name (California) isntead of the abbreviation (CA). Some existing code checks for measure.legislature_name.length === 2 to define state bills, so I reworked the code to no longer do that.

Specifically, I fixed it so that state flag maps show up instead of local.png (see below)

Live
![image](https://user-images.githubusercontent.com/39286778/62133177-f61cb280-b2a3-11e9-882f-6ffa879ec93e.png)

Localhost
![image](https://user-images.githubusercontent.com/39286778/62133765-008b7c00-b2a5-11e9-901f-293ccfdbbf82.png)


I also removed the use of stateNames replaced the name function as both are no longer necessary