### PR TITLE
Improve language identifying Legislature for states, cities & counties

### DIFF
--- a/views/endorsement-page.js
+++ b/views/endorsement-page.js
@@ -168,7 +168,7 @@ const rep = (r) => {
 const legislature = (measure) => {
   const notLocal = measure.legislature_name.length === 2 || measure.legislature_name === 'U.S. Congress'
   const measureImage = notLocal ? `${ASSETS_URL}/legislature-images/${measure.legislature_name}.png` : `${ASSETS_URL}/legislature-images/local.png`
-  const name = measure.legislature_name.length === 2 ? stateNames[measure.legislature_name] : measure.legislature_name
+  const generalAssemblyStates = "'Alaska', 'Colorado', 'Connecticut', 'Delaware', 'Illinois', 'Iowa', 'Maryland', 'Mississippi', 'Ohio', 'Pennsylvania', ' Rhode Island', 'Tennessee', 'Virginia'"
 
   return html`
     <div class="column">
@@ -179,8 +179,14 @@ const legislature = (measure) => {
           </div>
         </div>
         <div class="media-content has-text-weight-semibold is-size-5" style="line-height: 24px;">
-          ${name}<br />
-          ${measure.legislature_name === 'U.S. Congress' ? '' : 'Legislature'}
+          ${measure.legislature_name}<br />
+          ${measure.legislature_name === 'U.S. Congress' ? ''
+          : measure.legislature_name.includes('County') || measure.legislature_name.includes('San Francisco') ? 'Supervisors'
+          : measure.legislature_name.includes('Miami') ? 'Commission'
+          : measure.legislature_name.includes(',') ? 'Council' // other than SF & Miami all top 50 cities use some variation of Council
+          : generalAssemblyStates.includes(measure.legislature_name) ? 'General Assembly'
+          : measure.legislature_name === 'Massachusetts' || measure.legislature_name === 'New Hampshire' ? 'General Court'
+          : 'State Legislature'}
         </div>
       </div>
     </div>


### PR DESCRIPTION
On the endorsement page, we put Legislature for all jurisdictions except Congress. 

This pr adds the appropriate name for states (State Legislature, General Assembly, General Court), changes Legislature to Supervisor for counties, and makes Council the default for cities. I checked the top 50 cities and they all use some variation of Council (Common Council, City Council, General Council, etc), except Miami and SF, which I added special language for

I created an unusual check for states where the legislature should be called General Assembly, but I confirmed it's working by testing it with Wisconsin and California

![image](https://user-images.githubusercontent.com/39286778/62137497-a80bad00-b2ab-11e9-9cd7-e55e45ef0430.png)

![image](https://user-images.githubusercontent.com/39286778/62137552-c4a7e500-b2ab-11e9-808a-403c5657a6af.png)

![image](https://user-images.githubusercontent.com/39286778/62137744-12245200-b2ac-11e9-83f7-797bf2200aec.png)
