### PR TITLE
Add line explaining gravatar to edit-profile-page

### DIFF
--- a/views/edit-profile-page.js
+++ b/views/edit-profile-page.js
@@ -11,6 +11,10 @@ module.exports = ({ error, loading, user, forms: { profile: profileForm = {} } }
       <div class="container is-widescreen">
         <h2 class="title is-5">Edit Profile</h2>
         <form method="POST" onsubmit=${handleForm(dispatch, { type: 'profile:userProfileSaved', user })} onkeyup=${handleForm(dispatch, { type: 'profile:userProfileFormChanged' })}>
+          <div class="is-size-6">
+            <label class="label">Image</label>
+            Update your image on <a href="http://gravatar.com">Gravatar</a> to change your profile picture.
+          </div><br />
           <div class="field">
             <label class="label">Intro Video</label>
             <div class="control">


### PR DESCRIPTION
Currently, we don't alert users about Gravatar on the profile page or edit-profile-page. This pr adds a quick sentence about it to the page

![image](https://user-images.githubusercontent.com/39286778/62140316-66c9cc00-b2b0-11e9-93cf-693910f7e403.png)


