### PR TITLE
Fix Congress image for petitions

### DIFF
--- a/views/endorsement-page.js
+++ b/views/endorsement-page.js
@@ -167,7 +167,7 @@ const rep = (r) => {
 
 const legislature = (measure) => {
   const local = measure.legislature_name.includes(',') || measure.legislature_name.includes('County')
-  const measureImage = local ? `${ASSETS_URL}/legislature-images/local.png` : `${ASSETS_URL}/legislature-images/${stateAbbreviations[measure.legislature_name]}.png`
+  const measureImage = local ? `${ASSETS_URL}/legislature-images/local.png` : `${ASSETS_URL}/legislature-images/${stateAbbreviations[measure.legislature_name] || 'U.S. Congress'}.png`
 
   return html`
     <div class="column">


### PR DESCRIPTION
Noticed this while testing after David's question; forgot to account for Congressional images in my redo

Current live
![image](https://user-images.githubusercontent.com/39286778/62151284-98995d80-b2c5-11e9-995d-7d3bf5f90d15.png)


Testing on localhost:

![image](https://user-images.githubusercontent.com/39286778/62151342-ba92e000-b2c5-11e9-8adb-2b07c0927bac.png)


![image](https://user-images.githubusercontent.com/39286778/62151315-acdd5a80-b2c5-11e9-9e62-2a16acd01c50.png)

![image](https://user-images.githubusercontent.com/39286778/62151373-c8486580-b2c5-11e9-98cf-6fc54dfbbd52.png)

![image](https://user-images.githubusercontent.com/39286778/62151397-d4ccbe00-b2c5-11e9-9611-6419c73ac8d0.png)
