### PR TITLE
Allow all users to import arguments

### DIFF
--- a/models/import.js
+++ b/models/import.js
@@ -8,7 +8,7 @@ module.exports = (event, state) => {
         case '/legislation/:shortId/import':
         case '/nominations/:shortId/import':
         case '/:username/:shortId/import':
-          if (!state.user || !state.user.is_admin) return [{ ...state, loading: { page: true } }, redirect('/')]
+          if (!state.user) return [{ ...state, loading: { page: true } }, redirect('/')]
           return [state]
         default:
           return [state]

--- a/views/import-vote-page.js
+++ b/views/import-vote-page.js
@@ -6,9 +6,9 @@ module.exports = ({ error, location, user }, dispatch) => {
       <div class="container is-widescreen">
         <h2 class="title is-size-5">Import Argument to <a href=${location.path.slice(0, -7)}>${location.params.shortId}</a></h2>
 
-        ${!user || !user.is_admin ? html`<div class="notification is-danger">You do not have permission to import votes.</div>` : ''}
+        ${!user ? html`<div class="notification is-danger">You do not have permission to import votes.</div>` : ''}
 
-        <form onsubmit=${handleForm(dispatch, { type: 'import:voteImportFormSubmitted', short_id: location.params.shortId })} class=${user && user.is_admin ? '' : 'is-hidden'}>
+        <form onsubmit=${handleForm(dispatch, { type: 'import:voteImportFormSubmitted', short_id: location.params.shortId })} class=${user ? '' : 'is-hidden'}>
 
           ${error ? html`<div class="notification is-danger">${error.message}</div>` : ''}
 

--- a/views/measure-votes.js
+++ b/views/measure-votes.js
@@ -58,7 +58,7 @@ module.exports = (state, dispatch) => {
                 </button>
               </div>
             </div>
-            ${user && user.is_admin ? html`
+            ${user && user ? html`
               <div class="field is-narrow">
                 <div class="control">
                   <a href=${`${location.path}/import`} class="button is-link has-text-weight-semibold is-small">


### PR DESCRIPTION
This change removes the four is_admin checks on the front-end that prevent people from accessing the import page.

We have to make changes in the backend to allow those arguments to be saved:

https://github.com/voteliquid/api.liquid.us/pull/90