### PR TITLE
Change source for import votes from short link to source

### DIFF
--- a/views/vote.js
+++ b/views/vote.js
@@ -51,7 +51,7 @@ module.exports = (state, dispatch) => {
                   : anonymousName}
             </span>
             ${html`<span>voted <strong style="${`color: ${position === 'yea' ? 'hsl(141, 80%, 38%)' : (position === 'abstain' ? 'default' : 'hsl(348, 80%, 51%)')};`}">${position}</strong>${onBehalfOfCount > 1 && is_public ? html` on behalf of <span class="has-text-weight-semibold">${onBehalfOfCount}</span> people` : ''}${is_public ? '' : ' privately'}</span>`}
-            ${source_url ? html`<span class="is-size-7"> via <a href="${source_url}" target="_blank">${source_url.split('/')[2] || source_url}</a></span>` : ''}
+            ${source_url ? html`<span class="is-size-7"> <a href="${source_url}" target="_blank">[source]</a></span>` : ''}
           </div>
           ${showBill ? html`<div style="margin-bottom: .5rem;"><a href="${measure_url}">${measure_title}</a></div>` : ''}
           ${comment ? commentContent(key, vote, parent, dispatch) : ''}


### PR DESCRIPTION
As requested by David: replace the text on imported votes 

from:
via <a href=$full-url-to-source>$domain.com</a>

to:
[<a href=$full-url>source</a>]

so it will look like:

[source]
[source]
[source]

for all of them. Source is a hyperlink but not a variable itself, it’s meant to always say “source”.

Live: 
![image](https://user-images.githubusercontent.com/39286778/63199119-74b67580-c042-11e9-87e8-64b7b955dbe8.png)

localhost after changes:
![image](https://user-images.githubusercontent.com/39286778/63199144-86981880-c042-11e9-832d-c374beda54e9.png)


