### PR TITLE
Remove sidebar column on petition page for medium sized pages

### DIFF
--- a/views/endorsement-page.js
+++ b/views/endorsement-page.js
@@ -63,6 +63,9 @@ module.exports = (state, dispatch) => {
               .small-screens-only {
                 display: block;
               }
+              .sticky-panel.column {
+                display: none;
+              }
               @media (min-width: 1050px) {
                 .sticky-panel.column {
                   display: block;


### PR DESCRIPTION
Currently, if you shrink the petition page down, the sign up sidebar goes away, but the column is still there

![image](https://user-images.githubusercontent.com/39286778/63444621-945fec00-c3fc-11e9-9590-5a27caebb8e8.png)

This pr hides that column when appropriate
![image](https://user-images.githubusercontent.com/39286778/63444669-ae013380-c3fc-11e9-9bf7-20a5fc677941.png)
