### PR TITLE
Fix import path for vote pages

### DIFF
--- a/views/measure-comments.js
+++ b/views/measure-comments.js
@@ -34,6 +34,8 @@ const filtersView = (state, dispatch) => {
   const { path, query } = location
   const { order, position } = query
   const prevOffset = Math.max(0, Number(pagination.offset) - Number(pagination.limit))
+  const importLink = location.path.includes('/vote') ? location.path.split('/vote')[0] : location.path
+
   return html`
     <form
       name="vote-filters"
@@ -110,7 +112,7 @@ const filtersView = (state, dispatch) => {
           ${user && user.is_admin ? html`
             <div class="field is-narrow">
               <div class="control">
-                <a href=${`${location.path}/import`} class="button is-link has-text-weight-semibold is-small">
+                <a href=${`${importLink}/import`} class="button is-link has-text-weight-semibold is-small">
                   <span class="icon">${icon(faPlus)}</span>
                   <span>Import external argument</span>
                 </a>


### PR DESCRIPTION
When someone clicks on a vote link, the import external argument button is still visible below, but it no longer works because import is applied after the vote_id. This creates a variable that splits the url at /votes so that the import link works correctly.

https://liquid.us/dallascole/should-nancy-pelosi-be-speaker/votes/e5108116-b1e8-4cda-9854-22b025264777
![image](https://user-images.githubusercontent.com/39286778/66225925-3ed75a00-e69f-11e9-981e-7464f0434c9e.png)
